### PR TITLE
remove hard-coded test-data, organize test-data, fix test-methods

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -78,11 +78,11 @@ bash ./scripts/create-migration.sh
 Initially no test data are loaded into the memory. If you require sample data provided by the app you can set a 
 flag to your environment `LOAD_TEST_DATA` or change the boolean flag [here](vars.py). Additionally, the test-data can
 be modified with a patient containing a time-limited state. The timelimit of the state can also be configured [here](vars.py).
-Loading test data creates two execution in the memory containing the same content despite the players' id. The details 
+Loading test data creates two execution in memory containing the same content except the players' IDs. The details 
 are as follows:
 
-| status  | id | player ids             |
-|---------|----|------------------------| 
-| Pending | 1  | - 123ABC<br/>- 456DEF  |
-| Running | 2  | - 987ZYX<br/>- 654WVU) |
+| status  | ID | player IDs            |
+|---------|----|-----------------------| 
+| Pending | 1  | - 123ABC<br/>- 456DEF |
+| Running | 2  | - 987ZYX<br/>- 654WVU |
 

--- a/server/README.md
+++ b/server/README.md
@@ -73,3 +73,16 @@ make migration
 ```bash
 bash ./scripts/create-migration.sh
 ```
+
+## Working with test-data
+Initially no test data are loaded into the memory. If you require sample data provided by the app you can set a 
+flag to your environment `LOAD_TEST_DATA` or change the boolean flag [here](vars.py). Additionally, the test-data can
+be modified with a patient containing a time-limited state. The timelimit of the state can also be configured [here](vars.py).
+Loading test data creates two execution in the memory containing the same content despite the players' id. The details 
+are as follows:
+
+| status  | id | player ids             |
+|---------|----|------------------------| 
+| Pending | 1  | - 123ABC<br/>- 456DEF  |
+| Running | 2  | - 987ZYX<br/>- 654WVU) |
+

--- a/server/execution/entities/stategraphs/patientstate.py
+++ b/server/execution/entities/stategraphs/patientstate.py
@@ -22,7 +22,7 @@ class PatientState:
         self.treatments = treatments
         self.conditions = conditions
 
-    def add_treatment(self, treatment: str, new_state_uuid: str, reveals: list[str], force_update: bool = False):
+    def add_treatment(self, treatment: str, new_state_uuid: str, force_update: bool = False):
         """
             Inserts an additional treatment, that leads to a state change. If the treatment is already
             provided it keeps the old state unless the force_update flags allows an overwrite.

--- a/server/execution/run.py
+++ b/server/execution/run.py
@@ -7,31 +7,17 @@ separate file (FIXME: docu update @Louis)
 import logging
 
 from execution.entities.execution import Execution
-from execution.entities.player import Player
-from execution.entities.scenario import Scenario
 from execution.tests.entities import dummy_entities
-
-# FIXME: Remove hardcoded test data
-# TEST DATA
-player_a = Player("69", "Finn Bartels", False, 10,  None, set())
-
-test_a = Execution(1337, "ExcName", Scenario(17, "Test-Scenario-Pending", {}, {}, {}), {"69": player_a}, Execution.Status.PENDING)
-test_b = dummy_entities.create_test_execution()
-test_b.status = Execution.Status.RUNNING
+from vars import LOAD_TEST_DATA
 
 # Dictionary storing the currently available executions, whether they are PENDING, RUNNING or about to FINISH
 active_executions: dict[int, Execution] = {
     # "exec_id": "exec: execution_dbo"
-    1337: test_a,
-    test_b.id: test_b,
 }
 
 # Dictionary storing all active players in an execution
 registered_players: dict[str, int] = {
     # "TAN" : "exec_uuid"
-    "69": 1337,
-    "123ABC": test_b.id,
-    "456DEF": test_b.id,
 }
 
 
@@ -61,3 +47,12 @@ def remove_player(players):
             registered_players.pop(player.tan)
         except KeyError:
             logging.info(f"{player.tan} already removed")
+
+
+# TEST DATA
+if LOAD_TEST_DATA:
+    test_pending = dummy_entities.create_test_execution()
+    test_running = dummy_entities.create_test_execution(pending=False)
+
+    activate_execution(test_pending)
+    activate_execution(test_running)

--- a/server/execution/tests/api/test_action.py
+++ b/server/execution/tests/api/test_action.py
@@ -20,10 +20,10 @@ def test_perform_action(client):
     on their own.
     """
     # Player 1
-    headers = generate_token(client.application, running=True)
+    headers = generate_token(client.application)
     headers["Content-Type"] = "application/json"
     # Player 2
-    headers_p2 = generate_token(client.application, running=True)
+    headers_p2 = generate_token(client.application)
     headers_p2["Content-Type"] = "application/json"
 
     # Player 1: leave location
@@ -116,7 +116,7 @@ def test_perform_action_but_blocked_to_leaving(client):
     form = {
         "TAN": list(player_ids)[-1]
     }
-    headers = generate_token(client.application, running=True)
+    headers = generate_token(client.application)
     headers["Content-Type"] = "application/json"
     response = client.post(f"/api/login", data=json.dumps(form), headers=headers)
     assert response.status_code == http.HTTPStatus.OK

--- a/server/execution/tests/api/test_lobby.py
+++ b/server/execution/tests/api/test_lobby.py
@@ -31,7 +31,7 @@ def test_active_player(client):
 def test_current_exec_status(client):
     execution_id = list(execution_ids)[-1]
     test_execution: Execution = run.active_executions[execution_id]
-    headers = generate_token(client.application)
+    headers = generate_token(client.application, pending=True)
     headers_invalid_payload = generate_token(client.application, valid_payload=False)
 
     # status independent check
@@ -39,7 +39,7 @@ def test_current_exec_status(client):
     assert response.status_code == 204
 
     # status is RUNNING
-    headers = generate_token(client.application, running=True)
+    headers = generate_token(client.application)
     response = client.get("/api/scenario/start-time", headers=headers)
     assert response.status_code == 200
     assert response.json["starting_time"] == test_execution.starting_time
@@ -53,13 +53,12 @@ def test_current_exec_status(client):
 
 
 def test_set_name(client):
-    player_id = "654WVU"
+    player_id = "123ABC"
     exec_id = run.registered_players[player_id]
     execution = run.active_executions[exec_id]
     player = execution.players[player_id]
-    player.name = None
 
-    auth_header = generate_token(client.application)
+    auth_header = generate_token(client.application, pending=True)
     auth_header["Content-Type"] = "application/json"
     # initial set-name
     form = {

--- a/server/execution/tests/api/test_notification.py
+++ b/server/execution/tests/api/test_notification.py
@@ -3,8 +3,8 @@ from execution.tests.conftest import generate_token
 
 
 def test_get_notifications(client):
-    auth_header = generate_token(client.application, running=True)
-    execution = run.active_executions[1]
+    auth_header = generate_token(client.application)
+    execution = run.active_executions[2]
 
     messageA = "I am the first test-message."
     messageB = "I am the second test-message."

--- a/server/vars.py
+++ b/server/vars.py
@@ -1,2 +1,16 @@
+import os
 
 ACQUIRE_TIMEOUT = 3  # The timeout used to time out a locking-request
+
+# -- TESTING
+
+LOAD_TEST_DATA = os.getenv('LOAD_TEST_DATA')
+if not LOAD_TEST_DATA:
+    LOAD_TEST_DATA = True  # If LOAD_TEST_DATA is not set, assign a default boolean value
+
+# a patient will be assigned with a time dependent activity diagram
+INCLUDE_TIMELIMIT = True
+
+# configures the timelimit on a patient before the initial state is outdated.
+# Negative values invalided a state immediately
+PATIENT_TIMELIMIT = 10


### PR DESCRIPTION
This PR contains:

- time limit configuration for patients
- remove hard-coded test-data
- organize test-data
- make test data configurable.

This PR wont be merge before the LOAD_TEST_DATA flag is loaded via env for the pipeline and set default to false in code.