### PR TITLE
Feature/server/197 server start activitydiagrams of patients if execution is activated

### DIFF
--- a/server/execution/entities/execution.py
+++ b/server/execution/entities/execution.py
@@ -47,7 +47,7 @@ class Execution:
             raise InternalServerError("Execution without a scenario detected.")
         elif self.status == Execution.Status.RUNNING:
             # enables the patients activity-diagrams
-            self.scenario.hold_patients()
+            self.scenario.pause_patients()
         else:
             raise BadRequest("Process manipulation detected. Execution must be "
                              "RUNNING before pause.")

--- a/server/execution/entities/execution.py
+++ b/server/execution/entities/execution.py
@@ -1,6 +1,8 @@
 import json
 from enum import Enum
 
+from werkzeug.exceptions import InternalServerError, BadRequest
+
 from execution.entities.player import Player
 from execution.entities.scenario import Scenario
 from app_config import db
@@ -27,6 +29,28 @@ class Execution:
         self.status = status
         self.starting_time = starting_time
         self.notifications = []
+
+    def start_execution(self):
+        """ Performs the execution start protocol. """
+        if not self.scenario:
+            raise InternalServerError("Execution without a scenario detected.")
+        elif self.status == Execution.Status.PENDING:
+            # enables the patients activity-diagrams
+            self.scenario.run_patients()
+        else:
+            raise BadRequest("Process manipulation detected. Execution must be "
+                             "PENDING before start.")
+
+    def pause_execution(self):
+        """ Pauses execution components. """
+        if not self.scenario:
+            raise InternalServerError("Execution without a scenario detected.")
+        elif self.status == Execution.Status.RUNNING:
+            # enables the patients activity-diagrams
+            self.scenario.hold_patients()
+        else:
+            raise BadRequest("Process manipulation detected. Execution must be "
+                             "RUNNING before pause.")
 
     def __repr__(self):
         return (f"Execution(id={self.id!r}, scenario={self.scenario!r}, players={self.players!r}, "

--- a/server/execution/entities/patient.py
+++ b/server/execution/entities/patient.py
@@ -53,6 +53,14 @@ class Patient:
             self.activity_diagram.apply_treatment(str(action.id))
             return action.results
 
+    def start_activity_diagram(self):
+        """ Starts the activity diagram. """
+        self.activity_diagram.start_current_state()
+
+    def pause_activity_diagram(self):
+        """ Pauses the activity diagram. """
+        self.activity_diagram.pause_current_state()
+
     def to_dict(self, shallow: bool = False):
         """
         Returns all fields of this class in a dictionary. By default, all nested objects are included. In case the

--- a/server/execution/entities/scenario.py
+++ b/server/execution/entities/scenario.py
@@ -19,7 +19,7 @@ class Scenario:
         for patient in self.patients.values():
             patient.start_activity_diagram()
 
-    def hold_patients(self):
+    def pause_patients(self):
         for patient in self.patients.values():
             patient.pause_activity_diagram()
 

--- a/server/execution/entities/scenario.py
+++ b/server/execution/entities/scenario.py
@@ -15,6 +15,14 @@ class Scenario:
         self.actions = actions
         self.locations = locations
 
+    def run_patients(self):
+        for patient in self.patients.values():
+            patient.start_activity_diagram()
+
+    def hold_patients(self):
+        for patient in self.patients.values():
+            patient.pause_activity_diagram()
+
     def to_dict(self, shallow: bool = False):
         """
         Returns all fields of this class in a dictionary. By default, all nested objects are included. In case the

--- a/server/execution/entities/stategraphs/activity_diagram.py
+++ b/server/execution/entities/stategraphs/activity_diagram.py
@@ -73,10 +73,12 @@ class ActivityDiagram:
     def to_dict(self):
         result = {}
         for key, value in self.__dict__.items():
-            if hasattr(value, '__dict__'):
-                result[key] = value.to_dict()
+            if isinstance(value, TimeoutLock):
+                pass
             elif isinstance(value, dict):
                 result[key] = {dict_key: dictvalue.to_dict() for dict_key, dictvalue in value.items()}
+            elif hasattr(value, '__dict__'):
+                result[key] = value.to_dict()
             else:
                 result[key] = value
         return result

--- a/server/execution/entities/stategraphs/activity_diagram.py
+++ b/server/execution/entities/stategraphs/activity_diagram.py
@@ -20,6 +20,14 @@ class ActivityDiagram:
 
         self.__create_state_dict(states)
 
+    def start_current_state(self):
+        """ Initiates the timer of 'current' state of the activity-diagram. """
+        self.current.start_timer()
+
+    def pause_current_state(self):
+        """ Pauses the timer of the 'current' state of the activity-diagram. """
+        self.current.pause_timer()
+
     def apply_treatment(self, treatment: str):
         """
             A game-method to eventually change states after an action was performed.

--- a/server/execution/entities/stategraphs/activity_diagram.py
+++ b/server/execution/entities/stategraphs/activity_diagram.py
@@ -57,7 +57,7 @@ class ActivityDiagram:
             try:
                 new_state_uuid = self.current.treatments[treatment]
                 self.current = self.__get_state_by_id(new_state_uuid)
-                if self.current.timelimit != -1:
+                if self.current.timelimit >= 0:
                     self.current.start_timer()
             except KeyError:
                 logging.debug(

--- a/server/execution/entities/stategraphs/patientstate.py
+++ b/server/execution/entities/stategraphs/patientstate.py
@@ -18,7 +18,7 @@ class PatientState:
             conditions = {}
 
         # the time the state was delayed due to a pause action
-        self.pause_time = 0
+        self.pause_time = -1
 
         self.uuid = state_uuid
         self.start_time = start_time
@@ -80,7 +80,7 @@ class PatientState:
         if self.pause_time > 0:
             # add the delay to the timestamp
             self.start_time = self.start_time + (current_s - self.pause_time)
-            self.pause_time = 0  # reset pause_timer
+            self.pause_time = -1  # reset pause_timer
         else:
             self.start_time = current_s
 

--- a/server/execution/entities/stategraphs/patientstate.py
+++ b/server/execution/entities/stategraphs/patientstate.py
@@ -15,6 +15,9 @@ class PatientState:
         if not conditions:
             conditions = {}
 
+        # the time the state was delayed due to a pause action
+        self.pause_time = 0
+
         self.uuid = state_uuid
         self.start_time = start_time
         self.timelimit = timelimit
@@ -65,13 +68,26 @@ class PatientState:
         return conditions
 
     def start_timer(self):
-        """ Initiates a timer for the state object, if a timelimit is set. """
-        if self.timelimit != -1:
-            self.start_time = time.current_time_s()
-            return True
+        """
+        Initiates/restarts a timer for the state object, if a timelimit is set.
+        """
+        if self.timelimit == -1:
+            return
+
+        current_s = time.current_time_s()
+        if self.pause_time > 0:
+            # add the delay to the timestamp
+            self.start_time = self.start_time + (current_s - self.pause_time)
+            self.pause_time = 0  # reset pause_timer
         else:
-            logging.error("unable to start error, due to missing run time.")
-            return False
+            self.start_time = current_s
+
+    def pause_timer(self):
+        """ Pauses the state by setting a pause timestamp. """
+        if self.timelimit != -1:
+            return
+
+        self.pause_time = time.current_time_s()
 
     def get_all_child_state_ids(self):
         return set(self.treatments.values()).add(self.after_time_state_uuid)

--- a/server/execution/tests/conftest.py
+++ b/server/execution/tests/conftest.py
@@ -59,3 +59,18 @@ def generate_token(app, valid_payload=True, pending=False, plid="123ABC"):
         return {
             "Authorization": f"Bearer {jwt.encode(payload_invalid, app.config["JWT_SECRET_KEY"], algorithm="HS256")}"
         }
+
+
+def generate_webtoken(app):
+    payload = {
+        # This is the custom claim added by flask_jwt_extended which holds the
+        # value of the identity parameter passed during token creation.
+        "identity": "admin",
+        # This is the standard JWT claim (subject) which also holds the value
+        # of the identity parameter. This is where flask_jwt_extended places the
+        # identity by default.
+        "sub": "admin"
+    }
+    return {"Authorization": f"Bearer {jwt.encode(payload,
+                                                  app.config["JWT_SECRET_KEY"],
+                                                  algorithm="HS256")}"}

--- a/server/execution/tests/conftest.py
+++ b/server/execution/tests/conftest.py
@@ -28,8 +28,7 @@ def app():
     yield flask_app
 
     # Clean up
-    run.deactivate_execution(1)
-    run.deactivate_execution(2)
+    run.active_executions = {}
 
 
 @pytest.fixture()

--- a/server/execution/tests/services/test_entityloader.py
+++ b/server/execution/tests/services/test_entityloader.py
@@ -140,3 +140,6 @@ def test_load_execution():
             assert ex.status == Execution.Status.PENDING
             assert ex.name is not None
             assert ex.starting_time == -1
+
+    # CLEANUP - The fixture clean up of pytest does not apply after this test.
+    run.active_executions = {}

--- a/server/execution/tests/web_api/test_lobby.py
+++ b/server/execution/tests/web_api/test_lobby.py
@@ -1,0 +1,70 @@
+import http
+
+from execution import run
+from execution.entities.execution import Execution
+from execution.tests.conftest import generate_webtoken
+
+
+def test_execution_state_change(client):
+    """ Tests the execution state changes of the lobby patch method. """
+    auth_header = generate_webtoken(client.application)
+
+    # PER DEFAULT
+    # id=1 PENDING
+    # id=2 RUNNING
+    # id of {3, 4, 23456} in DB UNKNOWN
+
+    def _test_illegal_state_changes(exec_id, unwanted_status_list):
+        for unwanted_status in unwanted_status_list:
+            if exec_id in run.active_executions.keys():
+                status_before = run.active_executions[exec_id].status
+            else:
+                status_before = Execution.Status.UNKNOWN
+            # test illegal state changes
+            response = client.patch(f"/web/execution?id={exec_id}",
+                                    headers=auth_header,
+                                    data={"new_status": unwanted_status})
+
+            assert response.status_code == 400
+            if exec_id in run.active_executions.keys():
+                assert run.active_executions[
+                           exec_id].status == status_before
+            else:
+                assert exec_id not in run.active_executions.keys()
+
+    def _test_legal_state_changes(exec_id, wanted_status_list):
+        for wanted_status in wanted_status_list:
+            response = client.patch(f"/web/execution?id={exec_id}",
+                                    headers=auth_header,
+                                    data={"new_status": wanted_status})
+            assert response.status_code == 200
+            assert run.active_executions[
+                       exec_id].status == Execution.Status[wanted_status]
+
+    # Status: PENDING
+    # test illegal state changes
+    _test_illegal_state_changes(1, ["FINISHED", "UNKNOWN"])
+
+    # test legal state changes
+    _test_legal_state_changes(1, ["PENDING", "RUNNING"])
+
+    # Status: RUNNING
+    # test illegal state changes
+    _test_illegal_state_changes(2, ["UNKNOWN"])
+
+    # test legal state changes
+    _test_legal_state_changes(1,
+                              ["PENDING", "RUNNING", "FINISHED"])
+
+    # Status: FINISHED
+    # TODO
+
+    # Status: UNKNOWN
+    # test illegal state changes
+    _test_illegal_state_changes(3,
+                                ["RUNNING", "FINISHED", "UNKNOWN"])
+    # test legal state changes
+    _test_legal_state_changes(3,
+                              ["PENDING"])
+
+

--- a/server/execution/tests/web_api/test_lobby.py
+++ b/server/execution/tests/web_api/test_lobby.py
@@ -1,5 +1,3 @@
-import http
-
 from execution import run
 from execution.entities.execution import Execution
 from execution.tests.conftest import generate_webtoken
@@ -53,7 +51,7 @@ def test_execution_state_change(client):
     _test_illegal_state_changes(2, ["UNKNOWN"])
 
     # test legal state changes
-    _test_legal_state_changes(1,
+    _test_legal_state_changes(2,
                               ["PENDING", "RUNNING", "FINISHED"])
 
     # Status: FINISHED

--- a/server/execution/web_api/lobby.py
+++ b/server/execution/web_api/lobby.py
@@ -166,14 +166,18 @@ def __perform_state_change(new_status: Execution.Status, execution: Execution):
     match new_status:
         case Execution.Status.RUNNING:
             # RUNNING only occurs after a PENDING
-            if execution.status == Execution.Status.PENDING:
+            if execution.status == Execution.Status.RUNNING:
+                return
+            elif execution.status == Execution.Status.PENDING:
                 execution.start_execution()
             else:
                 raise BadRequest("Process manipulation detected. "
                                  "Invalid State change")
         case Execution.Status.PENDING:
             # PENDING occurs after UNKNOWN (DB load) and RUNNING
-            if execution.status == Execution.Status.RUNNING:
+            if execution.status == Execution.Status.PENDING:
+                return
+            elif execution.status == Execution.Status.RUNNING:
                 execution.pause_execution()
             elif execution.status == Execution.Status.UNKNOWN:
                 run.activate_execution(execution)
@@ -181,9 +185,14 @@ def __perform_state_change(new_status: Execution.Status, execution: Execution):
                 raise BadRequest("Process manipulation detected. "
                                  "Invalid State change")
         case Execution.Status.FINISHED:
-            # FIXME Garbage Collection?
-            # FIXME Stat Review?
-            pass
+            if execution.status == Execution.Status.FINISHED:
+                return
+            elif execution.status == Execution.Status.RUNNING:
+                # TODO implement archive mechanisms
+                return
+            else:
+                raise BadRequest("Process manipulation detected. "
+                                 "Invalid State change")
         case _:
             raise BadRequest("Process manipulation detected. "
                              "Invalid State change")

--- a/server/execution/web_api/lobby.py
+++ b/server/execution/web_api/lobby.py
@@ -11,7 +11,6 @@ from event_logging.event import Event
 from execution import run
 from execution.entities.execution import Execution
 from execution.services import entityloader
-from execution.services.entityloader import load_execution
 from execution.utils.util import try_get_execution
 from utils import time
 from utils.decorator import required, admin_only, RequiredValueSource, cache
@@ -106,15 +105,14 @@ def create_execution(scenario_id: int, name: str):
 def change_execution_status(id: int, new_status: str):
     execution = try_get_execution(id)
     try:
-        execution.status = Execution.Status[new_status]
-        if execution.id not in run.active_executions.keys():
-            run.activate_execution(execution)
+        new_status_enum = Execution.Status[new_status]
+        __perform_state_change(new_status_enum, execution)
+        execution.status = new_status_enum
+        return Response(status=200)
+
     except KeyError:
-        raise BadRequest(
-            f"Not an option for the execution status: '{new_status}'. "
-            f"Possible values are: "
-            f"{str.join(', ', [e.name for e in Execution.Status])}")
-    return Response(status=200)
+        raise BadRequest(f"Not an option for the execution status: "
+                         f"'{new_status}'. ")
 
 
 @web_api.patch("/execution/player/status")
@@ -162,3 +160,30 @@ def __get_roles() -> List[models.Role]:
 @cache
 def __get_top_level_locations() -> List[models.Location]:
     return models.Location.query.where(models.Location.location_id.is_(None)).all()
+
+
+def __perform_state_change(new_status: Execution.Status, execution: Execution):
+    match new_status:
+        case Execution.Status.RUNNING:
+            # RUNNING only occurs after a PENDING
+            if execution.status == Execution.Status.PENDING:
+                execution.start_execution()
+            else:
+                raise BadRequest("Process manipulation detected. "
+                                 "Invalid State change")
+        case Execution.Status.PENDING:
+            # PENDING occurs after UNKNOWN (DB load) and RUNNING
+            if execution.status == Execution.Status.RUNNING:
+                execution.pause_execution()
+            elif execution.status == Execution.Status.UNKNOWN:
+                run.activate_execution(execution)
+            else:
+                raise BadRequest("Process manipulation detected. "
+                                 "Invalid State change")
+        case Execution.Status.FINISHED:
+            # FIXME Garbage Collection?
+            # FIXME Stat Review?
+            pass
+        case _:
+            raise BadRequest("Process manipulation detected. "
+                             "Invalid State change")


### PR DESCRIPTION
This PR connects the patient activity diagrams with the state changes of the game master. Therefore the web_api method is extended by the required logic. Further every runtime entity, that is processed during the call, contains a method to pass the command to the activity diagram. 

The implementation of the switch to FINISHED is skipped and only marked as TODO, because it requires a more complex archive structure, which should be done in a separate issue.