### PR TITLE
update take-from, add put-to, update api.yml

### DIFF
--- a/doc/server/api_game/api.yaml
+++ b/doc/server/api_game/api.yaml
@@ -235,21 +235,28 @@ paths:
       security:
         - bearerAuth: [ ]
 
-  /run/location/take-from:
+  /run/location/take-to:
     post:
-      summary: A player 'takes' a sublocation, accessible to the players current location. It will be placed into the players inventory.
+      summary: A player takes any location which is not a registered top-level location and places another selected location. 
+               It is designed to create a valuable state among all locations and player inventories. However an invalid use may 
+               create an invalid game state. 
+               Remember - a player can only take from a location if he is assigned to a top-level location (vehicle or patient). 
+               The 'take_location_ids' list starts with the players current location. 
+               The 'to_location_ids' list ALWAYS starts with a top-level location (vehicle or patient)
       requestBody:
         required: true
         content:
           application/json:
             schema:
               type: object
-              required: [ take_location_id, from_location_id ]
+              required: [ take_location_ids, to_location_ids ]
               properties:
-                take_location_id:
-                  type: integer
-                from_location_id:
-                  type: integer
+                take_location_ids:
+                  type: string
+                  example: "[1,2,3]"
+                to_location_ids:
+                  type: string
+                  example: "[1,2,3]"
       responses:
         '200':
           description: accessible locations (the inventory) are updated.
@@ -267,7 +274,52 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
-          description: (Take-/From-) Location not found. Update your current location-access.
+          description: (Take-/to-) Location not found. Update your current location-access.
+        '409':
+          description: Unable to access runtime object. A timeout-error occurred.
+      security:
+        - bearerAuth: [ ]
+
+  /run/location/put-to:
+    post:
+      summary: A player puts any location which is not a registered top-level location and places it into another selected location. 
+               It is designed to create a valuable state among all locations and player inventories. However an invalid use may 
+               create an invalid game state. 
+               Remember -
+               The 'put_location_ids' list ALWAYS starts with the currents players location followed by a location out of his inventory.
+               The 'to_location_ids' list ALWAYS starts with a top-level location (vehicle or patient).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [ put_location_ids, to_location_ids ]
+              properties:
+                put_location_ids:
+                  type: string
+                  example: "[1,2,3]"
+                to_location_ids:
+                  type: string
+                  example: "[1,2,3]"
+      responses:
+        '200':
+          description: accessible locations (the inventory) are updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  player_location:
+                    $ref: '#/components/schemas/LocationDTO'
+        '204':
+          description: No running execution detected.
+        '400':
+          description: Missing or invalid request parameter detected.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: (Put-/to-) Location not found. Update your current location-access.
         '409':
           description: Unable to access runtime object. A timeout-error occurred.
       security:

--- a/server/event_logging/event.py
+++ b/server/event_logging/event.py
@@ -53,14 +53,25 @@ class Event:
         })
 
     @staticmethod
-    def location_take_from(execution_id: int, time: int, player: str, take_location_id: int, from_location_id: int):
+    def location_take_from(execution_id: int, time: int, player: str, take_location_ids: list[int], to_location_ids: list[int]):
         """
         Creates an event representing the action of taking a location from another location.
         """
         return Event(execution=execution_id, type=Event.Type.LOCATION_TAKE_FROM, time=time, data={
             "player": player,
-            "take_location_id": take_location_id,
-            "from_location_id": from_location_id
+            "take_location_ids": take_location_ids,
+            "to_location_ids": to_location_ids
+        })
+
+    @staticmethod
+    def location_put_to(execution_id: int, time: int, player: str, put_location_ids: list[int], to_location_ids: list[int]):
+        """
+        Creates an event representing the action of putting a location into another location.
+        """
+        return Event(execution=execution_id, type=Event.Type.LOCATION_TAKE_FROM, time=time, data={
+            "player": player,
+            "put_location_ids": put_location_ids,
+            "to_location_ids": to_location_ids
         })
 
     @staticmethod

--- a/server/execution/api/location.py
+++ b/server/execution/api/location.py
@@ -1,12 +1,14 @@
-from flask import request
+import ast
+
 from flask import Blueprint
 from flask_jwt_extended import jwt_required
 
 from app_config import csrf
+from execution.entities.execution import Execution
 from execution.utils import util
-from execution.entities.location import Location
 from event_logging.event import Event
 from utils import time
+from utils.decorator import required, RequiredValueSource
 
 api = Blueprint("api-location", __name__)
 
@@ -25,54 +27,135 @@ def get_all_toplevel_location():
         return f"Missing or invalid request parameter detected.", 400
 
 
-@api.post("/location/take-from")
+@api.post("/location/take-to")
+@required("take_location_ids", int, RequiredValueSource.JSON)
+@required("to_location_ids", str, RequiredValueSource.JSON)
 @jwt_required()
 @csrf.exempt
-def get_location_out_of_location():
+def get_location_out_of_location(take_location_ids: str, to_location_ids: str):
     """
     Releases a sub location of the players current location. Afterward the
     location is an accessible location for the player.
-    Required Request Param:
-        required_loc_id:    location identifier that shall be added to the
-                            players inventory
+
+    @param take_location_ids: string of index list of the location the player
+                              wants to take into his inventory. The list should
+                              start with a toplevel location.
+                              example: "[1,2,3]"
+    @param to_location_ids: string of index list of the new locations parent in
+                            the players inventory. If the list is empty, the
+                            item is placed as on the root level of the
+                            inventory.
+                            example: "[1,2,3]"
     """
-    args: dict = request.get_json()
     try:
         execution, player = util.get_execution_and_player()
 
-        required_loc_id = int(args["take_location_id"])
-        from_loc_id = int(args["from_location_id"])
+        # convert string like "[1,2,3]" to an accessible list
+        take_location_ids = ast.literal_eval(take_location_ids)
+        to_location_ids = ast.literal_eval(to_location_ids)
 
-        # locate required parent location
-        from_location: Location = execution.scenario.locations[from_loc_id]
-        if from_location is None:
-            return ("From-Location not found. Update your current "
+        # locate the new location in the players location
+        to_location = get_location_from_index_list(to_location_ids,
+                                                   execution)
+
+        if to_location is None:
+            return ("To-Location not found. Update your current "
                     "location-access."), 404
 
-        parent_location, required_location = from_location.get_child_location_by_id(
-            required_loc_id)
-        if required_location is None:
+        take_location_parent = get_location_from_index_list(
+                                take_location_ids[:-1], execution)
+        take_location = take_location_parent[
+            take_location_ids[len(take_location_ids)-1]
+        ]
+
+        if not take_location:
             return ("Take-Location not found. Update your current "
                     "location-access."), 404
 
-        assert parent_location  # pyright
+        to_location.add_locations({take_location})
 
-        # no lock needed, because only the requesting player can edit its own inventory
-        player.accessible_locations.add(required_location)
-        parent_location.remove_location_by_id(required_location.id)
-        if player.location:
-            # add location back to first children of the tree, to make it reachable for the leave-operation.
-            player.location.add_locations({required_location})
-            Event.location_take_from(execution_id=execution.id,
-                                     time=time.current_time_s(),
-                                     player=player.tan,
-                                     take_location_id=required_loc_id,
-                                     from_location_id=from_loc_id).log()
-            return {"player_location": player.location.to_dict()}
+        if to_location.id == player.location.id:
+            # if to_location is the player location -> the take_location should
+            # be placed in the inventory to guarantee a valid leave action.
+            player.accessible_locations.add(take_location)
         else:
-            return "Invalid state detected. Player has no location assigned", 418
+            # delete only from the location if the player location is different.
+            # In this case the player does not share the resources with any
+            # other player
+            take_location_parent.remove_location_by_id(take_location.id)
 
-    except KeyError:
+        Event.location_take_from(execution_id=execution.id,
+                                 time=time.current_time_s(),
+                                 player=player.tan,
+                                 take_location_ids=take_location_ids,
+                                 to_location_ids=to_location_ids).log()
+
+        return {"player_location": player.location.to_dict()}
+
+    except KeyError | ValueError:
+        return "Missing or invalid request parameter detected.", 400
+
+    except TimeoutError:
+        return "Unable to access runtime object. A timeout-error occurred.", 409
+
+
+@api.post("/location/put-to")
+@required("put_location_ids", int, RequiredValueSource.JSON)
+@required("to_location_ids", str, RequiredValueSource.JSON)
+@jwt_required()
+@csrf.exempt
+def put_location_to_location(put_location_ids: str, to_location_ids: str):
+    """
+    A method to transfer a location to another location. It can be used to
+    put items out of the inventory to another selected location.
+
+    @param put_location_ids: string of index list of location ids that is
+                             selected for transfer
+                             example: "[1,2,3]"
+    @param to_location_ids: string of index list of location ids the selected
+                            put location is selected to be placed in.
+                            example: "[1,2,3]"
+    """
+    try:
+        execution, player = util.get_execution_and_player()
+
+        # convert string like "[1,2,3]" to an accessible list
+        put_location_ids = ast.literal_eval(put_location_ids)
+        to_location_ids = ast.literal_eval(to_location_ids)
+
+        to_location = get_location_from_index_list(to_location_ids, execution)
+        if not to_location:
+            return ("To-Location not found. Update your current "
+                    "location-access."), 404
+
+        put_location_parent = get_location_from_index_list(
+                                put_location_ids[:-1], execution)
+        put_location = put_location_parent[
+            put_location_ids[len(put_location_ids)-1]
+        ]
+
+        if not put_location_parent or not put_location:
+            return ("Put-Location not found. Update your current "
+                    "location-access."), 404
+
+        if put_location_parent == player.location.id:
+            # if location parent is the players current location -> only the
+            # inventory is edited to guarantee a valid leave action.
+            player.accessible_locations.pop(put_location)
+        else:
+            # otherwise perform default remove and add action
+            put_location_parent.remove_location_by_id(put_location.id)
+            to_location.add_locations({put_location})
+
+        Event.location_put_to(execution_id=execution.id,
+                              time=time.current_time_s(),
+                              player=player.tan,
+                              put_location_ids=put_location_ids,
+                              to_location_ids=to_location_ids).log()
+
+        return {"player_location": player.location.to_dict()}
+
+    except KeyError | ValueError:
         return "Missing or invalid request parameter detected.", 400
 
     except TimeoutError:
@@ -102,3 +185,16 @@ def leave_location():
         return "Unable to access runtime object. A timeout-error occurred.", 409
 
     return {"message": "Player successfully left location."}
+
+
+def get_location_from_index_list(id_list: list[int], execution: Execution):
+    target_location = None
+    if not id_list:
+        return target_location
+    for i in range(len(id_list)):
+        if i == 0:
+            target_location = execution.scenario.locations[id_list[i]]
+        else:
+            target_location = target_location.sub_locations[id_list[i]]
+
+    return target_location

--- a/server/execution/entities/location.py
+++ b/server/execution/entities/location.py
@@ -41,8 +41,9 @@ class Location:
 
     def get_location_by_id(self, location_id: int):
         """
-        Retrieves a location of the stored locations. If the list is blocked
-        more than 3 seconds the methods raises a TimeoutError.
+        Retrieves a location of the stored toplevel sub-locations.
+        If the list is blocked more than 3 seconds the methods raises a
+        TimeoutError.
         """
         with self.loc_lock.acquire_timeout(timeout=ACQUIRE_TIMEOUT) as acquired:
             if acquired:


### PR DESCRIPTION
This PR contains contains 

- changes take-from -> take-to
- adds put to
- updates api.yml

The implementation of the new endpoint is aligned with the updated version of take-to. Major changes are the required parameter, which changed from a single id to a list of ids stored as string (required for backend structures). Based on these changes the logic as changed but is still designed to simulate a players inventory. However this methods remain untested.

@lukas0820 @n00on 
The methods may look similar, but contain major differences in the details, for example when a location is added or removed into the players inventory. Therfore to simulate a location transfer from one player to another:

1. Player A places a location at the required location using "put-to"
2. Player B takes the location using "take-to"

An invalid move would be to only perform a single "take-to" from Player B out of the inventory of Player A. Due to the fact that Player A hasnt released the item yet it is still mapped to Player A and will be lost if Player A leaves a location. 

A usage description is placed in the api.yml. I am well aware of the fact, that you could easily fill a full chapter of documentation to the edge cases and usages of these two methods. However time is ticking. If any questions occur during the implemantation, please reach out to me. I try to be highly available.