### PR TITLE
Bugfix/server/254 put to endpoint location assignment required duplication of locations

### DIFF
--- a/doc/server/api_game/api.yaml
+++ b/doc/server/api_game/api.yaml
@@ -322,6 +322,8 @@ paths:
           description: (Put-/to-) Location not found. Update your current location-access.
         '409':
           description: Unable to access runtime object. A timeout-error occurred.
+        '418':
+          description: Trying to move a top level location. You ain't that strong.
       security:
         - bearerAuth: [ ]
 

--- a/doc/server/api_game/api.yaml
+++ b/doc/server/api_game/api.yaml
@@ -259,14 +259,7 @@ paths:
                   example: "[1,2,3]"
       responses:
         '200':
-          description: accessible locations (the inventory) are updated.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  player_location:
-                    $ref: '#/components/schemas/LocationDTO'
+          description: Location successfully transferred.
         '204':
           description: No running execution detected.
         '400':
@@ -304,14 +297,7 @@ paths:
                   example: "[1,2,3]"
       responses:
         '200':
-          description: accessible locations (the inventory) are updated.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  player_location:
-                    $ref: '#/components/schemas/LocationDTO'
+          description: Location successfully transferred.
         '204':
           description: No running execution detected.
         '400':

--- a/server/execution/api/location.py
+++ b/server/execution/api/location.py
@@ -71,7 +71,7 @@ def get_location_out_of_location(take_location_ids, to_location_ids):
         take_location_id_list: list[int] = ast.literal_eval(take_location_ids)
         to_location_id_list: list[int] = ast.literal_eval(to_location_ids)
 
-        if not take_location_id_list or to_location_id_list:
+        if not take_location_id_list:
             return "Empty id-list provided. Unable to identify location.", 400
 
         if not player.location:
@@ -118,7 +118,7 @@ def get_location_out_of_location(take_location_ids, to_location_ids):
                                  take_location_ids=take_location_id_list,
                                  to_location_ids=to_location_id_list).log()
 
-        return {"player_location": player.location.to_dict()}
+        return "Location successfully transferred", 200
 
     except KeyError | ValueError:
         return "Missing or invalid request parameter detected.", 400
@@ -181,7 +181,7 @@ def put_location_to_location(put_location_ids, to_location_ids):
                                       player=player.tan,
                                       put_location_ids=put_location_id_list,
                                       to_location_ids=to_location_id_list).log()
-                return {"player_location": {}}
+                return "Location successfully transferred", 200
 
         else:
             # player has patient access. Inventory is located at patients location
@@ -219,7 +219,7 @@ def put_location_to_location(put_location_ids, to_location_ids):
                               put_location_ids=put_location_id_list,
                               to_location_ids=to_location_id_list).log()
 
-        return {"player_location": player.location.to_dict()}
+        return "Location successfully transferred", 200
 
     except KeyError | ValueError:
         return "Missing or invalid request parameter detected.", 400

--- a/server/execution/api/location.py
+++ b/server/execution/api/location.py
@@ -206,6 +206,9 @@ def put_location_to_location(put_location_ids, to_location_ids):
             # inventory is edited to guarantee a valid leave action.
             player.accessible_locations.remove(put_location)
         else:
+            if player.get_location_from_inventory(put_location.id):
+                # put location is top-level in inventory
+                player.accessible_locations.remove(put_location)
             # otherwise perform default remove and add action
             put_location_parent.remove_location_by_id(put_location.id)
             to_location.add_locations({put_location})

--- a/server/execution/entities/location.py
+++ b/server/execution/entities/location.py
@@ -27,7 +27,10 @@ class Location:
         self.name = name
         self.media_references = media_references
         self.resources = resources
+
+        # type 'set', because inventory can be managed by union and - operations
         self.sub_locations = sub_locations
+
         self.is_vehicle = is_vehicle
 
         self.res_lock = TimeoutLock()

--- a/server/execution/entities/player.py
+++ b/server/execution/entities/player.py
@@ -34,6 +34,10 @@ class Player:
             self.alerted = False
             self.alerted_timestamp = -1
 
+    def get_location_from_inventory(self, location_id):
+        return next((location for location in self.accessible_locations if
+                     location.id == location_id), None)
+
     def __repr__(self):
         return (
             f"Player(tan={self.tan!r}, \

--- a/server/execution/tests/api/test_location.py
+++ b/server/execution/tests/api/test_location.py
@@ -44,10 +44,7 @@ def ttest_put_toplevel_inventory_location(client):
     response = client.post("/api/run/location/put-to", headers=headers,
                            data=json.dumps(form))
     assert response.status_code == HTTPStatus.OK
-    response_json_put = response.get_json()
     response_inventory = client.get("/api/run/player/inventory",
                                     headers=headers)
     assert response_inventory.status_code == HTTPStatus.OK
-    response_json_inventory = response_inventory.get_json()
-    assert response_json_inventory
 

--- a/server/execution/tests/api/test_location.py
+++ b/server/execution/tests/api/test_location.py
@@ -29,3 +29,25 @@ def test_put_without_player_location(client):
     response = client.post("/api/run/location/put-to", headers=headers,
                            data=json.dumps(form))
     assert response.status_code == HTTPStatus.OK
+
+
+def ttest_put_toplevel_inventory_location(client):
+    # Disabled, because the test has IDE debugger use only.
+    headers = generate_token(client.application)
+    headers["Content-Type"] = "application/json"
+
+    form = {
+        "put_location_ids": "[1, 2]",
+        "to_location_ids": "[5]"
+    }
+
+    response = client.post("/api/run/location/put-to", headers=headers,
+                           data=json.dumps(form))
+    assert response.status_code == HTTPStatus.OK
+    response_json_put = response.get_json()
+    response_inventory = client.get("/api/run/player/inventory",
+                                    headers=headers)
+    assert response_inventory.status_code == HTTPStatus.OK
+    response_json_inventory = response_inventory.get_json()
+    assert response_json_inventory
+

--- a/server/execution/tests/api/test_location.py
+++ b/server/execution/tests/api/test_location.py
@@ -1,3 +1,6 @@
+import json
+from http import HTTPStatus
+
 from conftest import generate_token
 
 
@@ -8,3 +11,21 @@ def test_player_inventory(client):
     response_data = response.get_json()
     assert response.status_code == 200
     assert len(response_data["accessible_locations"]) > 0
+
+
+def test_put_without_player_location(client):
+    headers = generate_token(client.application)
+    headers["Content-Type"] = "application/json"
+
+    # leave location
+    response = client.post("/api/run/location/leave", headers=headers)
+    assert response.status_code == HTTPStatus.OK
+
+    form = {
+        "put_location_ids": "[2]",
+        "to_location_ids": "[5]"
+    }
+
+    response = client.post("/api/run/location/put-to", headers=headers,
+                           data=json.dumps(form))
+    assert response.status_code == HTTPStatus.OK


### PR DESCRIPTION
This PR includes the first draft ob bugs mentioned in #254.

- Fixed: Put and Take work with empty player location
- Fixed: Put dont copy from inventory, if location is top-level in players inventory
- Updated: take/put return str on 200.
- Updated: added error case for unintentially moving top level location

Usage of location_index_lists:

case put:
- empty parameters will fail.
- if player is located at a location -> use global toplevel location as starting index. Mutation and the implemented bugfix update inventory automatically
- if player is NOT assigned to any location, use an inventory-toplevel location as first id.

case take:
- empty parameter take_location_id_list will fail.
- empty to_location_id_list leads to an inventory toplevel placement. IF the player is assigned to a location, the location is updated as well. 
- to_location_id_list starts always with an inventory toplevel id. Mutation and the implemented bugfix update the players location automatically.