### PR TITLE
Fix/web/301 web can not create new players

### DIFF
--- a/server/dbsetup.py
+++ b/server/dbsetup.py
@@ -186,18 +186,24 @@ def __create_roles():
 
 
 def __create_players():
-    insert(Player(tan="123ABC", execution_id=1, location_id=0, role_id=1,
+    insert(Player(tan="123ABC", execution_id=4, location_id=0, role_id=1,
                   alerted=True, activation_delay_sec=120))
-    insert(Player(tan="987ZYX", execution_id=2, location_id=0,
+    insert(Player(tan="987ZYX", execution_id=5, location_id=0,
                   role_id=2, alerted=True, activation_delay_sec=10))
-    insert(Player(tan="654WVU", execution_id=2, location_id=0, role_id=3,
+    insert(Player(tan="654WVU", execution_id=5, location_id=0, role_id=3,
                   alerted=False, activation_delay_sec=10))
 
     insert(PlayersToVehicleInExecution(execution_id=4, scenario_id=2, player_tan="123ABC",
                                        location_id=0, vehicle_name="RTW I"))
+    insert(PlayersToVehicleInExecution(execution_id=4, scenario_id=2, player_tan="empty-RTW I",
+                                       location_id=0, vehicle_name="RTW I"))
     insert(PlayersToVehicleInExecution(execution_id=5, scenario_id=2, player_tan="987ZYX",
                                        location_id=0, vehicle_name="RTW I"))
+    insert(PlayersToVehicleInExecution(execution_id=5, scenario_id=2, player_tan="empty-RTW I",
+                                       location_id=0, vehicle_name="RTW I"))
     insert(PlayersToVehicleInExecution(execution_id=5, scenario_id=2, player_tan="654WVU",
+                                       location_id=0, vehicle_name="RTW II"))
+    insert(PlayersToVehicleInExecution(execution_id=5, scenario_id=2, player_tan="empty-RTW II",
                                        location_id=0, vehicle_name="RTW II"))
 
 

--- a/server/execution/entities/execution.py
+++ b/server/execution/entities/execution.py
@@ -115,16 +115,21 @@ class Execution:
         # take empty seat of vehicle
         player_to_vehicle = models.PlayersToVehicleInExecution.query.filter_by(
             execution_id=self.id,
-            vehicle_name=vehicle
+            vehicle_name=vehicle,
+            player_tan=f"empty-{vehicle}"
         ).first()
         if player_to_vehicle:
             # assign empty seat in vehicle
             player = (models.Player(tan=tan, execution_id=self.id, location_id=player_to_vehicle.location_id, role_id=role, alerted=False, activation_delay_sec=0))  # pyright: ignore [reportCallIssue]
-            player_to_vehicle.player_tan = tan
-            # create new empty seat in vehicle
-            new_seat_in_vehicle = models.PlayersToVehicleInExecution(execution_id=player_to_vehicle.execution_id, scenario_id=player_to_vehicle.scenario_id, player_tan="empty", location_id=player_to_vehicle.location_id, vehicle_name=player_to_vehicle.vehicle_name)  # pyright: ignore [reportCallIssue]
-            db.session.add(new_seat_in_vehicle)
             db.session.add(player)
+            player_to_vehicle.player_tan = tan
+            db.session.commit()
+
+            # create new empty seat in vehicle
+            # Here it is possible to implement a limitation of seats if required
+            new_seat_in_vehicle = models.PlayersToVehicleInExecution(execution_id=player_to_vehicle.execution_id, scenario_id=player_to_vehicle.scenario_id, player_tan=f"empty-{player_to_vehicle.vehicle_name}", location_id=player_to_vehicle.location_id, vehicle_name=player_to_vehicle.vehicle_name)  # pyright: ignore [reportCallIssue]
+            db.session.add(new_seat_in_vehicle)
+
             db.session.commit()
 
             # load player location -> choose from existing or load new vehicle

--- a/server/execution/web_api/lobby.py
+++ b/server/execution/web_api/lobby.py
@@ -171,7 +171,7 @@ def __get_roles() -> list[models.Role]:
     return models.Role.query.all()
 
 
-#@cache
+@cache
 def __get_top_level_locations(execution_id: int) -> List[models.Location]:
     return (models.PlayersToVehicleInExecution.query
             .filter_by(execution_id=execution_id)

--- a/server/execution/web_api/lobby.py
+++ b/server/execution/web_api/lobby.py
@@ -171,9 +171,12 @@ def __get_roles() -> list[models.Role]:
     return models.Role.query.all()
 
 
-@cache
+#@cache
 def __get_top_level_locations(execution_id: int) -> List[models.Location]:
-    return models.PlayersToVehicleInExecution.query.filter_by(execution_id=execution_id).all()
+    return (models.PlayersToVehicleInExecution.query
+            .filter_by(execution_id=execution_id)
+            .group_by(models.PlayersToVehicleInExecution.vehicle_name)
+            .all())
 
 
 def __perform_state_change(new_status: Execution.Status, execution: Execution):


### PR DESCRIPTION
This PR fixes a bug related to any player creation. The implementation required an empty seat entry inside the DB. However the test data as well as the claiming of the empty seat entry were incorrect. 