### PR TITLE
Feature/web/267 add file upload interface for base data

### DIFF
--- a/server/media/media_api.py
+++ b/server/media/media_api.py
@@ -11,6 +11,7 @@ from models import WebUser
 from utils.decorator import role_required
 
 api = Blueprint("api-media", __name__)
+web_api = Blueprint("web_api-media", __name__)
 
 
 def setup(app: Flask):
@@ -24,6 +25,7 @@ def setup(app: Flask):
     os.makedirs(os.path.join(app.root_path, "media/instance/text"),
                 exist_ok=True)
     app.register_blueprint(api, url_prefix="/media")
+    app.register_blueprint(web_api, url_prefix="/web/media")
 
 
 def is_allowed_format(filename: str):
@@ -43,7 +45,7 @@ def get_instance_media(filename):
     return send_from_directory("media/instance", filename)
 
 
-@api.post("/<path:filename>")
+@web_api.post("/<path:filename>")
 @role_required(WebUser.Role.SCENARIO_ADMIN)
 def post_instance_media(filename):
     """ Allows users to upload media files to the server. Returns a MediaData-JSON. """
@@ -103,7 +105,7 @@ def __handle_raw_text():
     if not text and not title:
         return "Invalid request: Missing 'text' or 'title' attribute", 400
 
-    return MediaData.new_text(title, text).to_json(), 201
+    return MediaData.new_text(text, title).to_json(), 201
 
 
 def __check_file_content(file: FileStorage) -> bool:

--- a/server/media/tests/test_media_api.py
+++ b/server/media/tests/test_media_api.py
@@ -29,7 +29,7 @@ def test_post_instance_media_file(client):
         data = {
             "file": (io.BytesIO(image_file.read()), "test.jpg")
         }
-        response = client.post("/media/test.jpg", headers=auth_header,
+        response = client.post("/web/media/test.jpg", headers=auth_header,
                                content_type="multipart/form-data", data=data)
 
     assert response.status_code == http.HTTPStatus.CREATED
@@ -52,7 +52,7 @@ def test_post_instance_media_file_with_attributes(client):
             "text": "Some test text.",
             "title": "The Title"
         }
-        response = client.post("/media/test.jpg", headers=auth_header,
+        response = client.post("/web/media/test.jpg", headers=auth_header,
                                content_type="multipart/form-data", data=data)
 
     assert response.status_code == http.HTTPStatus.CREATED
@@ -70,7 +70,7 @@ def test_post_instance_media_text(client):
     client.application.config['WTF_CSRF_METHODS'] = []
 
     auth_header = generate_webtoken(client.application, WebUser.Role.SCENARIO_ADMIN)
-    response = client.post("/media/txt", headers=auth_header, content_type="multipart/form-data",
+    response = client.post("/web/media/txt", headers=auth_header, content_type="multipart/form-data",
                            data={"text": "Test"})
 
     assert response.status_code == http.HTTPStatus.CREATED
@@ -87,7 +87,7 @@ def test_post_illegal_format(client):
         data = {
             "file": (io.BytesIO(illegal_file.read()), "illegal.py")
         }
-        response = client.post("/media/test.png", headers=auth_header,
+        response = client.post("/web/media/test.png", headers=auth_header,
                                content_type="multipart/form-data", data=data)
 
     assert response.status_code == http.HTTPStatus.BAD_REQUEST

--- a/server/media/tests/test_media_api.py
+++ b/server/media/tests/test_media_api.py
@@ -98,7 +98,7 @@ def test_unauthorized_post(client):
     client.application.config['WTF_CSRF_METHODS'] = []
 
     auth_header = generate_webtoken(client.application, WebUser.Role.GAME_MASTER)
-    response = client.post("/media/txt", headers=auth_header, content_type="multipart/form-data",
+    response = client.post("/web/media/txt", headers=auth_header, content_type="multipart/form-data",
                            data={"text": "Test"})
 
     assert response.status_code == http.HTTPStatus.FORBIDDEN

--- a/server/scenario/web_api/data/action.py
+++ b/server/scenario/web_api/data/action.py
@@ -27,6 +27,7 @@ def get_all_actions():
         {
             "id": action.id,
             "name": action.name,
+            "media_refs": action.media_refs
         } for action in action_list
     ]
 

--- a/server/scenario/web_api/data/location.py
+++ b/server/scenario/web_api/data/location.py
@@ -40,6 +40,7 @@ def get_all_locations():
         {
             "id": location.id,
             "name": location.name,
+            "media_refs": location.media_refs
         } for location in location_list
     ]
 

--- a/server/scenario/web_api/data/resource.py
+++ b/server/scenario/web_api/data/resource.py
@@ -25,6 +25,7 @@ def get_all_resources():
         {
             "id": resource.id,
             "name": resource.name,
+            "media_refs": resource.media_refs
         } for resource in resource_list
     ]
 

--- a/server/scenario/web_api/utils.py
+++ b/server/scenario/web_api/utils.py
@@ -21,7 +21,7 @@ def update_media(dbo: models.Action | models.Location | models.Resource,
     for add_media in media_refs_add:
         media_refs.append(add_media)
 
-    dbo.media_refs = media_refs
+    dbo.media_refs = json.dumps(media_refs)
 
 
 def __remove_media(media_refs, del_media):

--- a/web/src/components/mediaUpload.css
+++ b/web/src/components/mediaUpload.css
@@ -1,0 +1,60 @@
+#media-upload-section {
+    z-index: 999;
+    top: 15em;
+    left: 30em
+}
+
+.table-container {
+    max-height: 150px;
+    /* Set the height for scrollable table body */
+    overflow-y: auto;
+    /* Enable vertical scrolling */
+    margin-top: 10px;
+}
+
+.table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.sticky-header th {
+    position: sticky;
+    top: 0;
+    /* Stick the header to the top */
+    background-color: white;
+    /* Ensure the header is still visible */
+    z-index: 1;
+    /* Make sure the header is above other content */
+    box-shadow: 0 2px 2px -1px rgba(0, 0, 0, 0.4);
+    /* Optional: add shadow for clarity */
+}
+
+tbody td {
+    max-width: 10em;
+    overflow-x: auto;
+    white-space: nowrap;
+}
+
+@media screen and (max-width: 1399px) {
+    #media-upload-section {
+        left: 25em
+    }
+}
+
+@media screen and (max-width: 1299px) {
+    #media-upload-section {
+        left: 20em
+    }
+}
+
+@media screen and (max-width: 991px) {
+    #media-upload-section {
+        left: 15em
+    }
+}
+
+@media screen and (max-width: 767px) {
+    #media-upload-section {
+        left: 10em
+    }
+}

--- a/web/src/components/mediaUpload.tsx
+++ b/web/src/components/mediaUpload.tsx
@@ -1,0 +1,130 @@
+
+import { useState } from "react"
+import { BaseDataStripped, Media } from "../types"
+import "./mediaUpload.css"
+import { CsrfForm } from "./CsrfForm"
+
+interface MediaUploadProps {
+    data: BaseDataStripped
+    className: string,
+    uploadView: boolean,
+    setUploadView: React.Dispatch<React.SetStateAction<boolean>>,
+    dataType: string
+}
+
+const MediaUpload: React.FC<MediaUploadProps> = ({ data, className = '', uploadView, setUploadView, dataType }) => {
+    const [fileView, setFileView] = useState(true)
+    const [isText, setIsText] = useState("ntxt")
+    const [deleteMediaList, setDeleteMediaList] = useState<Media[]>([])
+
+    // Function to compare two media objects based on their properties
+    const isSameMedia = (media1: Media, media2: Media) => {
+        return (
+            media1.media_type === media2.media_type &&
+            media1.title === media2.title &&
+            media1.text === media2.text &&
+            media1.media_reference === media2.media_reference
+        );
+    };
+
+    // Function to check if a media is in the delete list
+    const isMediaInDeleteList = (media: Media) => {
+        return deleteMediaList.some((deletedMedia) => isSameMedia(deletedMedia, media));
+    };
+
+    return (
+        <section id="media-upload-section" className={`${uploadView ? "" : "d-none"} ${className}`}>
+            <div id="upload-header" className="d-flex mb-3">
+                <h1 className="fs-4 text-white">Datei-Upload: {data.name}-{data.id}</h1>
+                <button className="btn btn-danger ms-auto" onClick={() => {
+                    setUploadView(false)
+                    setDeleteMediaList([])
+                }
+                }>Abbrechen</button>
+
+            </div>
+            <CsrfForm id="media-upload-form" method="post" encType="multipart/form-data">
+                <input type="text" name="dataType" value={dataType} hidden readOnly />
+                <input type="text" name="type" value={isText} hidden readOnly />
+                <input type="text" name="id" value={data.id} hidden readOnly />
+
+                <div id="media-upload" className="bg-white rounded p-2 border-bottom">
+                    <div className="btn-group mb-2" role="group" aria-label="Basic radio toggle button group">
+                        <input type="radio" className="btn-check" name="fileView" id="btnradio1" autoComplete="off" checked={fileView} onClick={() => {
+                            setFileView(true)
+                            setIsText("ntxt")
+                        }
+                        } />
+                        <label className="btn btn-outline-primary" htmlFor="btnradio1">Datei</label>
+
+                        <input type="radio" className="btn-check" name="fileView" id="btnradio2" autoComplete="off" checked={!fileView} onClick={() => {
+                            setFileView(false)
+                            setIsText("txt")
+                        }
+                        } />
+                        <label className="btn btn-outline-primary" htmlFor="btnradio2">Frei Text</label>
+                    </div>
+                    <div id="upload-row" className="d-flex pb-2">
+                        <input type="text" id="media-title" className={`form-control me-2`} name="title" placeholder="Title" />
+                        <input type="file" name="file" id="media-file-input" className={`form-control ${fileView ? "" : "d-none"}`} />
+                        <button className="btn btn-primary ms-2" type="submit">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" className="bi bi-upload" viewBox="0 0 16 16">
+                                <path d="M.5 9.9a.5.5 0 0 1 .5.5v2.5a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2.5a.5.5 0 0 1 1 0v2.5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2v-2.5a.5.5 0 0 1 .5-.5" />
+                                <path d="M7.646 1.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1-.708.708L8.5 2.707V11.5a.5.5 0 0 1-1 0V2.707L5.354 4.854a.5.5 0 1 1-.708-.708z" />
+                            </svg>
+                        </button>
+                    </div>
+                    <label className={`${fileView ? "d-none" : ""}`}>Media Text</label>
+                    <textarea className={`me-2 ${fileView ? "d-none" : ""}`} rows={2} cols={120} name="text" form="media-upload-form" />
+                </div>
+            </CsrfForm>
+            <section id="current-media-files-table" className="mt-2 p-2 rounded bg-white">
+                <CsrfForm id="media-upload-form" method="patch">
+                    <input type="text" name="formType" value="delete" hidden readOnly />
+                    <input type="text" name="dataType" value={dataType} hidden readOnly />
+                    <input type="hidden" name="media_refs_del" value={JSON.stringify(deleteMediaList)} />
+                    <input type="text" name="id" value={data.id} hidden readOnly />
+                    <div id="upload-header" className="d-flex mb-3">
+                        <h1 className="fs-5 mb-3">Gespeicherte Medien</h1>
+                        <button className="btn btn-primary ms-auto" type="submit">Speichern</button>
+                    </div>
+                    <div className="table-container">
+                        <table className="table">
+                            <thead className="sticky-header">
+                                <tr>
+                                    <th scope="col">Media-Typ</th>
+                                    <th scope="col">Titel</th>
+                                    <th scope="col">Text</th>
+                                    <th scope="col">Referenz</th>
+                                </tr>
+                            </thead>
+                            <tbody className="">
+                                {data.media_refs === undefined ?
+                                    <tr>
+                                        <td>
+                                            No data to display
+                                        </td>
+                                    </tr> : JSON.parse(data.media_refs).map((media: Media, index: number) => (
+                                        <tr key={index} className={`${isMediaInDeleteList(media) ? "d-none" : ""}`}>
+                                            <td> {media.media_type || "ohne Typ"}</td>
+                                            <td> {media.title || "Ohne Titel"}</td>
+                                            <td> {media.text || "Kein Text"}</td>
+                                            <td> {media.media_reference || "Kein Link gespeichert"}</td>
+                                            <td className="ms-3 btn btn-outline-danger btn-sm w-50" onClick={() => {
+                                                if (!isMediaInDeleteList(media)) {
+                                                    setDeleteMediaList([...deleteMediaList, media]);
+                                                }
+                                            }}
+                                            >-</td>
+                                        </tr>))
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                </CsrfForm>
+            </section>
+        </section>
+    )
+}
+
+export default MediaUpload;

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -45,9 +45,10 @@ const router = createBrowserRouter([
         action: ScenarioEditor.action
       },
       {
-        path: "/data",
+        path: "/data/:windowId",
         element: <BaseDataRoute />,
-        loader: BaseDataRoute.loader
+        loader: BaseDataRoute.loader,
+        action: BaseDataRoute.action
       }
     ],
   },

--- a/web/src/routes/base-data.tsx
+++ b/web/src/routes/base-data.tsx
@@ -45,7 +45,7 @@ export function BaseDataRoute() {
             setUploadView(true)
             setDataType(dataType)
         }
-    }, [emptyBaseData, actions, locations, resources, windowId])
+    }, [actions, locations, resources, windowId])
 
     const handlePageNav = (showId: number) => {
         setShowActions(showId === 1);

--- a/web/src/routes/base-data.tsx
+++ b/web/src/routes/base-data.tsx
@@ -190,8 +190,8 @@ BaseDataRoute.action = async function ({ request }: ActionFunctionArgs<Request>)
     } else {
 
         // indicates if the backend should handle a raw txt
-        let type = formData.get("type")
-        let url = `media/${type}`
+        const type = formData.get("type")
+        const url = `media/${type}`
         const media = await tryFetchJson<Media>(url, {
             body: formData,
             method: "POST",
@@ -215,7 +215,7 @@ BaseDataRoute.action = async function ({ request }: ActionFunctionArgs<Request>)
 
     // Instead of redirecting, reload the current page
     if (response.ok) {
-        let url = `/data/${formData.get("dataType")}-${formData.get("id")}`
+        const url = `/data/${formData.get("dataType")}-${formData.get("id")}`
         console.log(url)
         window.location.href = url;
     } else {

--- a/web/src/routes/base-data.tsx
+++ b/web/src/routes/base-data.tsx
@@ -45,7 +45,7 @@ export function BaseDataRoute() {
             setUploadView(true)
             setDataType(dataType)
         }
-    }, [windowId])
+    }, [emptyBaseData, actions, locations, resources, windowId])
 
     const handlePageNav = (showId: number) => {
         setShowActions(showId === 1);

--- a/web/src/routes/base-data.tsx
+++ b/web/src/routes/base-data.tsx
@@ -1,29 +1,62 @@
-import { useLoaderData } from "react-router"
+import { ActionFunctionArgs, LoaderFunctionArgs, useLoaderData } from "react-router"
 import { getBaseData } from "../api/base-data"
-import { BaseDataStripped } from "../types"
+import { BaseDataStripped, Media } from "../types"
 import { Button } from "react-bootstrap"
-import { useState } from "react"
+import { useEffect, useState } from "react"
+import MediaUpload from "../components/mediaUpload"
+import { tryFetchJson } from "../api"
 
 type BaseData = {
     actions: Array<BaseDataStripped>
     locations: Array<BaseDataStripped>
     resources: Array<BaseDataStripped>
+    windowId: string
 }
 
 export function BaseDataRoute() {
-    const { actions, locations, resources } = useLoaderData() as BaseData
+    const { actions, locations, resources, windowId } = useLoaderData() as BaseData
 
     const [showActions, setShowActions] = useState(true)
     const [showLocations, setShowLocations] = useState(false)
     const [showResources, setShowResources] = useState(false)
 
+
+    const emptyBaseData = {
+        id: 0,
+        name: ""
+    }
+    const [editData, setEditData] = useState(emptyBaseData)
+    const [uploadView, setUploadView] = useState(false)
+
+    const [dataType, setDataType] = useState("")
+
+    useEffect(() => {
+        if (windowId !== "all") {
+            const windowIdSplit = windowId.split("-")
+            const dataType = windowIdSplit[0]
+            const id = +windowIdSplit[1]
+            if (dataType === "action") {
+                setEditData(actions.find(item => item.id === id) ?? emptyBaseData)
+            } else if (dataType === "location") {
+                setEditData(locations.find(item => item.id === id) ?? emptyBaseData)
+            } else if (dataType === "resource") {
+                setEditData(resources.find(item => item.id === id) ?? emptyBaseData)
+            }
+            setUploadView(true)
+            setDataType(dataType)
+        }
+    }, [windowId])
+
     const handlePageNav = (showId: number) => {
         setShowActions(showId === 1);
         setShowLocations(showId === 2);
         setShowResources(showId !== 1 && showId !== 2);
+        setUploadView(false)
     }
+
     return (
         <section>
+            <MediaUpload className="bg-secondary position-fixed p-3 rounded w-50" data={editData} uploadView={uploadView} setUploadView={setUploadView} dataType={dataType} />
             <section id="page-nav-section" className="d-flex justify-content-center mt-5">
                 <div className="d-flex justify-content-center border-2">
                     <div className={`btn ${showActions ? "active" : ""}`} onClick={() => handlePageNav(1)}>
@@ -50,7 +83,12 @@ export function BaseDataRoute() {
                                 <div id="action-name" className="ms-2 me-auto d-flex">
                                     <span className="align-self-center">{action.name}</span>
                                 </div>
-                                <Button className="btn-primary">Bearbeiten</Button>
+                                <Button className="btn-primary" onClick={() => {
+                                    setEditData(action)
+                                    setUploadView(true)
+                                    setDataType("action")
+                                }
+                                }>Bearbeiten</Button>
                             </li>
                         ))}
                     </div>
@@ -75,7 +113,12 @@ export function BaseDataRoute() {
                                 <div id="location-name" className="ms-2 me-auto d-flex">
                                     <span className="align-self-center">{location.name}</span>
                                 </div>
-                                <Button className="btn-primary">Bearbeiten</Button>
+                                <Button className="btn-primary" onClick={() => {
+                                    setEditData(location)
+                                    setUploadView(true)
+                                    setDataType("location")
+                                }
+                                }>Bearbeiten</Button>
                             </li>
                         ))}
                     </div>
@@ -100,26 +143,83 @@ export function BaseDataRoute() {
                                 <div id="resource-name" className="ms-2 me-auto d-flex">
                                     <span className="align-self-center">{resource.name}</span>
                                 </div>
-                                <Button className="btn-primary">Bearbeiten</Button>
+                                <Button className="btn-primary" onClick={() => {
+                                    setEditData(resource)
+                                    setUploadView(true)
+                                    setDataType("resource")
+                                }
+                                }>Bearbeiten</Button>
                             </li>
                         ))}
                     </div>
                 ) : (
-                    <div className="mt-5 d-flex justify-content-center border-bottom">
+                    <section className="mt-5 d-flex justify-content-center border-bottom">
                         <p>
                             <i>Es sind keine Ressourcen gespeichert.</i>
                         </p>
-                    </div>
+                    </section>
                 )}
             </section>
         </section>
     )
 }
 
-BaseDataRoute.loader = async function () {
+BaseDataRoute.loader = async function ({
+    params: { windowId },
+}: LoaderFunctionArgs) {
     const actions = await getBaseData(`data/action/all`)
     const locations = await getBaseData(`data/location/all`)
     const resources = await getBaseData(`data/resource/all`)
 
-    return { actions, locations, resources }
+    return { actions, locations, resources, windowId }
+}
+
+BaseDataRoute.action = async function ({ request }: ActionFunctionArgs<Request>) {
+    const formData = await request.formData()
+    // Get the CSRF token from the formData
+    const csrf = formData.get("csrf_token") ?? "nischt"
+    console.log("hi" + formData.get("file"))
+    const dataId = formData.get("id")
+    let data = {}
+    if (formData.get("formType") === "delete") {
+        console.log(formData.get("media_refs_del"))
+        data = {
+            id: dataId,
+            media_refs_del: JSON.parse(formData.get("media_refs_del") as string),
+        };
+    } else {
+
+        // indicates if the backend should handle a raw txt
+        let type = formData.get("type")
+        let url = `media/${type}`
+        const media = await tryFetchJson<Media>(url, {
+            body: formData,
+            method: "POST",
+        })
+
+        data = {
+            id: dataId,
+            media_refs_add: [media]
+        }
+    }
+
+    // Perform the PATCH request with the serialized JSON data
+    const response = await fetch(`/web/data/${formData.get("dataType")}`, {
+        method: "PATCH",
+        headers: {
+            "Content-Type": "application/json",
+            "X-CSRFToken": csrf.toString(), // Include CSRF token
+        },
+        body: JSON.stringify(data),
+    });
+
+    // Instead of redirecting, reload the current page
+    if (response.ok) {
+        let url = `/data/${formData.get("dataType")}-${formData.get("id")}`
+        console.log(url)
+        window.location.href = url;
+    } else {
+        console.error('Failed to update scenario:', response.text());
+    }
+    return ""
 }

--- a/web/src/routes/base-data.tsx
+++ b/web/src/routes/base-data.tsx
@@ -2,7 +2,7 @@ import { ActionFunctionArgs, LoaderFunctionArgs, useLoaderData } from "react-rou
 import { getBaseData } from "../api/base-data"
 import { BaseDataStripped, Media } from "../types"
 import { Button } from "react-bootstrap"
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import MediaUpload from "../components/mediaUpload"
 import { tryFetchJson } from "../api"
 
@@ -21,10 +21,12 @@ export function BaseDataRoute() {
     const [showResources, setShowResources] = useState(false)
 
 
-    const emptyBaseData = {
-        id: 0,
-        name: ""
-    }
+    const emptyBaseData = useMemo(() => {
+        return {
+            id: 0,
+            name: ""
+        }
+    }, []); // No dependencies, so it's only created once
     const [editData, setEditData] = useState(emptyBaseData)
     const [uploadView, setUploadView] = useState(false)
 
@@ -45,7 +47,7 @@ export function BaseDataRoute() {
             setUploadView(true)
             setDataType(dataType)
         }
-    }, [actions, locations, resources, windowId])
+    }, [emptyBaseData, actions, locations, resources, windowId])
 
     const handlePageNav = (showId: number) => {
         setShowActions(showId === 1);

--- a/web/src/routes/root.tsx
+++ b/web/src/routes/root.tsx
@@ -33,7 +33,7 @@ export function Root(): ReactElement {
           <Navbar.Collapse id="basic-navbar-nav">
             <Nav className="me-auto">
               <NavLink to="/executions" name="Ausführungen" />
-              <NavLink to="/data" name="Stammdaten" />
+              <NavLink to="/data/all" name="Stammdaten" />
               <NavDropdown title="Benutzer">
                 <NavDropdown.Header>
                   {getStorageItem("user")}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -87,11 +87,21 @@ export const isErrorResponse = isTypeFactory<ErrorResponse>(errorResponse)
 export const isLoginResponse = isTypeFactory<LoginResponse>(loginResponse)
 
 // MANVSim Data
+const media = z.object({
+  media_type: z.string(),
+  title: z.string().or(z.null()),
+  text: z.string().or(z.null()),
+  media_reference: z.string().or(z.null())
+})
+
+export type Media = z.infer<typeof media>
+
 const baseDataStripped = z.object({
   id: z.number(),
   name: z.string(),
   quantity: z.number().optional(),
-  travel_time: z.number().optional()
+  travel_time: z.number().optional(),
+  media_refs: z.string().optional(),
 })
 
 export type BaseDataStripped = z.infer<typeof baseDataStripped>
@@ -182,12 +192,6 @@ export type ExecutionData = z.infer<typeof executionData>
 export const isExecutionData = isTypeFactory<ExecutionData>(executionData)
 
 
-const media = z.object({
-  media_type: z.string(),
-  title: z.string().or(z.null()),
-  text: z.string().or(z.null()),
-  media_reference: z.string().or(z.null())
-})
 
 const actionData = z.object({
   id: z.number(),


### PR DESCRIPTION
This PR adds an media editor for base data. The user can now upload raw text or files. Further the user can delete existing media references. 
The user cant select files from an existing files due to missing endpoint in media api. This will be implemented in a seperate issue.

Please review the changes in the backend. They might be minimal. The FE was tested before pushing.