### PR TITLE
update player-vehicle assignment

### DIFF
--- a/server/dbsetup.py
+++ b/server/dbsetup.py
@@ -202,14 +202,7 @@ def __create_players():
                                        player_tan="456DEF", location_id=0,
                                        vehicle_name="RTW-Kiel", travel_time=60))
     insert(PlayersToVehicleInExecution(execution_id=1, scenario_id=0,
-                                       player_tan="empty-RTW-Kiel", location_id=0,
-                                       vehicle_name="RTW-Kiel", travel_time=60))
-    insert(PlayersToVehicleInExecution(execution_id=1, scenario_id=0,
                                        player_tan="789GHI", location_id=1,
-                                       vehicle_name="NEF-Eckernfoerde",
-                                       travel_time=120))
-    insert(PlayersToVehicleInExecution(execution_id=1, scenario_id=0,
-                                       player_tan="empty-NEF-Eckernfoerde", location_id=1,
                                        vehicle_name="NEF-Eckernfoerde",
                                        travel_time=120))
 

--- a/server/migrations/versions/af9b5710ea26_.py
+++ b/server/migrations/versions/af9b5710ea26_.py
@@ -1,8 +1,8 @@
 """empty message
 
-Revision ID: 5869f9e19ceb
+Revision ID: af9b5710ea26
 Revises: 
-Create Date: 2024-09-09 15:04:25.786403
+Create Date: 2024-09-18 17:31:16.789202
 
 """
 from alembic import op
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = '5869f9e19ceb'
+revision = 'af9b5710ea26'
 down_revision = None
 branch_labels = None
 depends_on = None
@@ -125,7 +125,7 @@ def upgrade():
     )
     op.create_table('player',
     sa.Column('tan', sa.String(), nullable=False),
-    sa.Column('execution_id', sa.Integer(), nullable=False),
+    sa.Column('execution_id', sa.Integer(), nullable=True),
     sa.Column('location_id', sa.Integer(), nullable=False),
     sa.Column('role_id', sa.Integer(), nullable=False),
     sa.Column('alerted', sa.Boolean(), nullable=False),
@@ -135,6 +135,7 @@ def upgrade():
     sa.PrimaryKeyConstraint('tan', name=op.f('pk_player'))
     )
     op.create_table('players_to_vehicle_in_execution',
+    sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
     sa.Column('execution_id', sa.Integer(), nullable=True),
     sa.Column('scenario_id', sa.Integer(), nullable=False),
     sa.Column('player_tan', sa.String(), nullable=True),
@@ -145,7 +146,7 @@ def upgrade():
     sa.ForeignKeyConstraint(['location_id'], ['location.id'], name=op.f('fk_players_to_vehicle_in_execution_location_id_location')),
     sa.ForeignKeyConstraint(['player_tan'], ['player.tan'], name=op.f('fk_players_to_vehicle_in_execution_player_tan_player')),
     sa.ForeignKeyConstraint(['scenario_id'], ['scenario.id'], name=op.f('fk_players_to_vehicle_in_execution_scenario_id_scenario')),
-    sa.PrimaryKeyConstraint('execution_id', 'player_tan', name=op.f('pk_players_to_vehicle_in_execution')),
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_players_to_vehicle_in_execution')),
     sa.UniqueConstraint('execution_id', 'scenario_id', 'vehicle_name', 'player_tan', name='unique_execution_vehicle')
     )
     # ### end Alembic commands ###

--- a/server/models.py
+++ b/server/models.py
@@ -21,13 +21,15 @@ class Role(db.Model):
 class Player(db.Model):
     tan: Mapped[str] = mapped_column(primary_key=True)
     execution_id: Mapped[int] = mapped_column(
-        ForeignKey("execution.id"), nullable=False)
+        ForeignKey("execution.id"), nullable=True)
     location_id: Mapped[int] = mapped_column(
         ForeignKey("location.id"), nullable=False)
     role_id: Mapped[int] = mapped_column(ForeignKey("role.id"), nullable=False)
     alerted: Mapped[bool] = mapped_column(nullable=False)
 
     execution: Mapped["Execution"] = relationship(back_populates="players")
+    vehicle = relationship("PlayersToVehicleInExecution",
+                           back_populates="player")
 
 
 # -- GAME --
@@ -117,13 +119,13 @@ class LocationContainsLocation(db.Model):
 
 
 class PlayersToVehicleInExecution(db.Model):
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     execution_id: Mapped[int] = mapped_column(ForeignKey("execution.id"),
-                                              primary_key=True,
                                               nullable=True)
     scenario_id: Mapped[int] = mapped_column(ForeignKey("scenario.id"),
                                              nullable=False)
     player_tan: Mapped[str] = mapped_column(ForeignKey("player.tan"),
-                                            nullable=True, primary_key=True)
+                                            nullable=True)
     location_id: Mapped[int] = mapped_column(ForeignKey("location.id"), nullable=False)
     vehicle_name: Mapped[str] = mapped_column(nullable=False)
     travel_time: Mapped[int] = mapped_column(nullable=False, default=0)
@@ -132,6 +134,8 @@ class PlayersToVehicleInExecution(db.Model):
         UniqueConstraint("execution_id", "scenario_id", "vehicle_name",
                          "player_tan", name="unique_execution_vehicle"),
     )
+
+    player = relationship("Player", back_populates="vehicle")
 
 
 class Resource(db.Model):

--- a/server/scenario/web_api/scenario.py
+++ b/server/scenario/web_api/scenario.py
@@ -1,13 +1,15 @@
 import logging
 
 from flask import Blueprint, request
-from sqlalchemy import select, distinct, asc
+from sqlalchemy import select, distinct, asc, desc
 from werkzeug.exceptions import NotFound, BadRequest
 
 import models
 from models import WebUser
 from app_config import db, csrf
+from utils.dbo import add_vehicles_to_execution_to_session
 from utils.decorator import role_required, required, RequiredValueSource
+from utils.tans import unique
 
 web_api = Blueprint("web_api-scenario", __name__)
 
@@ -187,10 +189,14 @@ def __update_vehicle_in_scenario(scenario, vehicles_add=None, vehicles_del=None)
     try:
         if vehicles_del:
             for vehicle_del in vehicles_del:
-                db.session.query(models.PlayersToVehicleInExecution).filter(
-                    models.PlayersToVehicleInExecution.scenario_id == scenario.id,
-                    models.PlayersToVehicleInExecution.vehicle_name == vehicle_del["name"]
-                ).delete()
+                vehicle_list = (models.PlayersToVehicleInExecution.query.
+                                filter_by(scenario_id=scenario.id,
+                                          vehicle_name=vehicle_del["name"])
+                                ).all()
+                player_list = [vehicle.player for vehicle in vehicle_list]
+
+                [db.session.delete(vehicle) for vehicle in vehicle_list]
+                [db.session.delete(player) for player in player_list]
 
         if vehicles_add:
             __add_vehicles_to_execution(scenario, vehicles_add)
@@ -224,12 +230,8 @@ def __add_vehicles_to_execution(scenario, vehicles_add):
     for vehicle_add in vehicles_add:
         # Add new vehicle to every execution stored for the scenario
         for exec_id in execution_ids:
-            vehicle = models.PlayersToVehicleInExecution(
-                execution_id=exec_id,
-                scenario_id=scenario.id,
-                location_id=vehicle_add["id"],
-                vehicle_name=vehicle_add["name"],
-                player_tan=f"empty-{vehicle_add["name"]}",
-                travel_time=vehicle_add["travel_time"]
+            add_vehicles_to_execution_to_session(
+                exec_id if exec_id != 0 else None,
+                scenario.id, vehicle_add["id"],
+                vehicle_add["name"], vehicle_add["travel_time"]
             )
-            db.session.add(vehicle)

--- a/server/utils/dbo.py
+++ b/server/utils/dbo.py
@@ -14,20 +14,20 @@ def add_vehicles_to_execution_to_session(
     highest_role = db.session.execute(role_query).first()
     tan = str(unique())
     player = (models.Player(
-        tan=tan,
-        execution_id=execution_id if execution_id != 0 else None,  # FK
-        location_id=vehicle_id,
-        role_id=highest_role[0],
-        alerted=False)
+        tan=tan, # type: ignore
+        execution_id=execution_id if execution_id != 0 else None,  # type: ignore
+        location_id=vehicle_id,  # type: ignore
+        role_id=highest_role[0],  # type: ignore
+        alerted=False)  # type: ignore
     )
     db.session.add(player)
 
     vehicle = models.PlayersToVehicleInExecution(
-        execution_id=execution_id if execution_id != 0 else None,  # FK
-        scenario_id=scenario_id,
-        location_id=vehicle_id,
-        vehicle_name=vehicle_name,
-        player_tan=tan,
-        travel_time=travel_time
+        execution_id=execution_id if execution_id != 0 else None,  # type: ignore
+        scenario_id=scenario_id,  # type: ignore
+        location_id=vehicle_id,  # type: ignore
+        vehicle_name=vehicle_name,  # type: ignore
+        player_tan=tan,  # type: ignore
+        travel_time=travel_time  # type: ignore
     )
     db.session.add(vehicle)

--- a/server/utils/dbo.py
+++ b/server/utils/dbo.py
@@ -1,0 +1,33 @@
+from sqlalchemy import select, desc
+
+import models
+from app_config import db
+from utils.tans import unique
+
+
+def add_vehicles_to_execution_to_session(
+    execution_id: int | None, scenario_id: int,
+    vehicle_id: int, vehicle_name: str, travel_time: int
+):
+    role_query = (select(models.Role.id, models.Role.power)
+                  .order_by(desc(models.Role.power)))
+    highest_role = db.session.execute(role_query).first()
+    tan = str(unique())
+    player = (models.Player(
+        tan=tan,
+        execution_id=execution_id if execution_id != 0 else None,  # FK
+        location_id=vehicle_id,
+        role_id=highest_role[0],
+        alerted=False)
+    )
+    db.session.add(player)
+
+    vehicle = models.PlayersToVehicleInExecution(
+        execution_id=execution_id if execution_id != 0 else None,  # FK
+        scenario_id=scenario_id,
+        location_id=vehicle_id,
+        vehicle_name=vehicle_name,
+        player_tan=tan,
+        travel_time=travel_time
+    )
+    db.session.add(vehicle)

--- a/web/src/routes/execution.tsx
+++ b/web/src/routes/execution.tsx
@@ -149,6 +149,7 @@ export function ExecutionRoute() {
                     <CsrfForm method="POST" className="my-2">
                       <input name="id" value={"delete-player"} hidden />
                       <input type="text" name="tan" value={player.tan} hidden />
+                      <input type="text" name="vehicle" value={player.location?.name} hidden />
                       <button className="btn btn-outline-danger w-100">Löschen</button>
                     </CsrfForm>
                   </div>


### PR DESCRIPTION
Based on the postgres errors the following changes were applied:

- By adding a new entry to the PlayersToVehicleInExecution Table, a new player is created with highest power possible and referenced in the same entry.
- to prevent further problems with the primary key being null the PlayersToVehicleInExecution Table has a separate specific primary key
- no matter how many executions or player in an execution are deleted of a scenario: for every vehicle remains an entry with a predefined player.

Lot of User processes were tested using the frontend and it turned out to be stable after all. The endboss will be Postgres.

Will be merged after review of @simohlsen. 