### PR TITLE
create inmemory db for test, separate client/app fixtures

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -9,17 +9,13 @@ on:
       - bug/server/**
 
 jobs:
-  setup:
+  
+  typecheck:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
-    outputs:
-      working-directory: ${{ steps.set-working-directory.outputs.working-directory }}
-    
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
 
-      # Setup Python (faster than using Python container)
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
@@ -35,29 +31,38 @@ jobs:
         run: |
           pipenv install
 
-  lint:
-    needs: setup
-    runs-on: ubuntu-latest
-    working-directory: server
-    steps:
       - name: Run linter
+        working-directory: server
         run: |
           pipenv run lint
 
-  typecheck:
-    needs: setup
-    runs-on: ubuntu-latest
-    working-directory: server
-    steps:
       - name: Run Type Checker
+        working-directory: server
         run: |
           pipenv run typecheck
 
   test:
-    needs: setup
     runs-on: ubuntu-latest
-    working-directory: server
     steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.12"
+
+      - name: Install pipenv
+        working-directory: server
+        run: |
+          python -m pip install --upgrade pipenv
+
+      - name: Install dependencies
+        working-directory: server
+        run: |
+          pipenv install
+
       - name: Run pytest
+        working-directory: server
         run: |
           pipenv run pytest

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
@@ -45,10 +45,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -38,26 +38,26 @@ jobs:
   lint:
     needs: setup
     runs-on: ubuntu-latest
+    working-directory: server
     steps:
       - name: Run linter
-        working-directory: server
         run: |
           pipenv run lint
 
   typecheck:
     needs: setup
     runs-on: ubuntu-latest
+    working-directory: server
     steps:
       - name: Run Type Checker
-        working-directory: server
         run: |
           pipenv run typecheck
 
   test:
     needs: setup
     runs-on: ubuntu-latest
+    working-directory: server
     steps:
       - name: Run pytest
-        working-directory: server
         run: |
           pipenv run pytest

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -9,10 +9,12 @@ on:
       - bug/server/**
 
 jobs:
-  test:
+  setup:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-
+    outputs:
+      working-directory: ${{ steps.set-working-directory.outputs.working-directory }}
+    
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
@@ -33,28 +35,28 @@ jobs:
         run: |
           pipenv install
 
+  lint:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
       - name: Run linter
         working-directory: server
         run: |
           pipenv run lint
 
+  typecheck:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
       - name: Run Type Checker
         working-directory: server
         run: |
           pipenv run typecheck
 
-      - name: Initialize database
-        working-directory: server
-        run: |
-          pipenv run flask --app main db init 2>/dev/null | true
-          pipenv run flask --app main db upgrade
-
-      - name: Load test data to database
-        working-directory: server
-        run: |
-          pipenv run python dbsetup.py
-
-      # Test server component
+  test:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
       - name: Run pytest
         working-directory: server
         run: |

--- a/server/Pipfile
+++ b/server/Pipfile
@@ -22,6 +22,7 @@ flask-cors = "*"
 python-magic = "*"
 psycopg2-binary = "*"
 pytz = "*"
+python-magic-bin = "*"
 
 [dev-packages]
 

--- a/server/Pipfile
+++ b/server/Pipfile
@@ -22,7 +22,6 @@ flask-cors = "*"
 python-magic = "*"
 psycopg2-binary = "*"
 pytz = "*"
-python-magic-bin = "*"
 
 [dev-packages]
 

--- a/server/Pipfile.lock
+++ b/server/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0b225e8da440fcc216b778c42754dd04453105787aab9756a3c9d7eb01cb56c7"
+            "sha256": "761cd40cb856b1e64990295d196ffc1e68be4dce3fd0ecaefbeec102cecd9228"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -524,15 +524,6 @@
             "index": "pypi",
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==0.4.27"
-        },
-        "python-magic-bin": {
-            "hashes": [
-                "sha256:34a788c03adde7608028203e2dbb208f1f62225ad91518787ae26d603ae68892",
-                "sha256:7b1743b3dbf16601d6eedf4e7c2c9a637901b0faaf24ad4df4d4527e7d8f66a4",
-                "sha256:90be6206ad31071a36065a2fc169c5afb5e0355cbe6030e87641c6c62edc2b69"
-            ],
-            "index": "pypi",
-            "version": "==0.4.14"
         },
         "python-string-utils": {
             "hashes": [

--- a/server/Pipfile.lock
+++ b/server/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "761cd40cb856b1e64990295d196ffc1e68be4dce3fd0ecaefbeec102cecd9228"
+            "sha256": "0b225e8da440fcc216b778c42754dd04453105787aab9756a3c9d7eb01cb56c7"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,19 +18,19 @@
     "default": {
         "alembic": {
             "hashes": [
-                "sha256:1ff0ae32975f4fd96028c39ed9bb3c867fe3af956bd7bb37343b54c9fe7445ef",
-                "sha256:6b8733129a6224a9a711e17c99b08462dbf7cc9670ba8f2e2ae9af860ceb1953"
+                "sha256:203503117415561e203aa14541740643a611f641517f0209fcae63e9fa09f1a2",
+                "sha256:908e905976d15235fae59c9ac42c4c5b75cfcefe3d27c0fbf7ae15a37715d80e"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.13.2"
+            "version": "==1.13.3"
         },
         "astroid": {
             "hashes": [
-                "sha256:0e14202810b30da1b735827f78f5157be2bbd4a7a59b7707ca0bfc2fb4c0063a",
-                "sha256:413658a61eeca6202a59231abb473f932038fbcbf1666587f66d482083413a25"
+                "sha256:5eba185467253501b62a9f113c263524b4f5d55e1b30456370eed4cdbd6438fd",
+                "sha256:e73d0b62dd680a7c07cb2cd0ce3c22570b044dd01bd994bc3a2dd16c6cbba162"
             ],
-            "markers": "python_full_version >= '3.8.0'",
-            "version": "==3.2.4"
+            "markers": "python_full_version >= '3.9.0'",
+            "version": "==3.3.4"
         },
         "bcrypt": {
             "hashes": [
@@ -101,11 +101,11 @@
         },
         "dill": {
             "hashes": [
-                "sha256:3ebe3c479ad625c4553aca177444d89b486b1d84982eeacded644afc0cf797ca",
-                "sha256:c36ca9ffb54365bdd2f8eb3eff7d2a21237f8452b57ace88b1ac615b7e815bd7"
+                "sha256:468dff3b89520b474c0397703366b7b95eebe6303f108adf9b19da1f702be87a",
+                "sha256:81aa267dddf68cbfe8029c42ca9ec6a4ab3b22371d1c450abc54422577b4512c"
             ],
             "markers": "python_version >= '3.11'",
-            "version": "==0.3.8"
+            "version": "==0.3.9"
         },
         "flask": {
             "hashes": [
@@ -179,75 +179,82 @@
         },
         "greenlet": {
             "hashes": [
-                "sha256:01059afb9b178606b4b6e92c3e710ea1635597c3537e44da69f4531e111dd5e9",
-                "sha256:037d9ac99540ace9424cb9ea89f0accfaff4316f149520b4ae293eebc5bded17",
-                "sha256:0e49a65d25d7350cca2da15aac31b6f67a43d867448babf997fe83c7505f57bc",
-                "sha256:13ff8c8e54a10472ce3b2a2da007f915175192f18e6495bad50486e87c7f6637",
-                "sha256:1544b8dd090b494c55e60c4ff46e238be44fdc472d2589e943c241e0169bcea2",
-                "sha256:184258372ae9e1e9bddce6f187967f2e08ecd16906557c4320e3ba88a93438c3",
-                "sha256:1ddc7bcedeb47187be74208bc652d63d6b20cb24f4e596bd356092d8000da6d6",
-                "sha256:221169d31cada333a0c7fd087b957c8f431c1dba202c3a58cf5a3583ed973e9b",
-                "sha256:243a223c96a4246f8a30ea470c440fe9db1f5e444941ee3c3cd79df119b8eebf",
-                "sha256:24fc216ec7c8be9becba8b64a98a78f9cd057fd2dc75ae952ca94ed8a893bf27",
-                "sha256:2651dfb006f391bcb240635079a68a261b227a10a08af6349cba834a2141efa1",
-                "sha256:26811df4dc81271033a7836bc20d12cd30938e6bd2e9437f56fa03da81b0f8fc",
-                "sha256:26d9c1c4f1748ccac0bae1dbb465fb1a795a75aba8af8ca871503019f4285e2a",
-                "sha256:28fe80a3eb673b2d5cc3b12eea468a5e5f4603c26aa34d88bf61bba82ceb2f9b",
-                "sha256:2cd8518eade968bc52262d8c46727cfc0826ff4d552cf0430b8d65aaf50bb91d",
-                "sha256:2d004db911ed7b6218ec5c5bfe4cf70ae8aa2223dffbb5b3c69e342bb253cb28",
-                "sha256:3d07c28b85b350564bdff9f51c1c5007dfb2f389385d1bc23288de51134ca303",
-                "sha256:3e7e6ef1737a819819b1163116ad4b48d06cfdd40352d813bb14436024fcda99",
-                "sha256:44151d7b81b9391ed759a2f2865bbe623ef00d648fed59363be2bbbd5154656f",
-                "sha256:44cd313629ded43bb3b98737bba2f3e2c2c8679b55ea29ed73daea6b755fe8e7",
-                "sha256:4a3dae7492d16e85ea6045fd11cb8e782b63eac8c8d520c3a92c02ac4573b0a6",
-                "sha256:4b5ea3664eed571779403858d7cd0a9b0ebf50d57d2cdeafc7748e09ef8cd81a",
-                "sha256:4c3446937be153718250fe421da548f973124189f18fe4575a0510b5c928f0cc",
-                "sha256:5415b9494ff6240b09af06b91a375731febe0090218e2898d2b85f9b92abcda0",
-                "sha256:5fd6e94593f6f9714dbad1aaba734b5ec04593374fa6638df61592055868f8b8",
-                "sha256:619935a44f414274a2c08c9e74611965650b730eb4efe4b2270f91df5e4adf9a",
-                "sha256:655b21ffd37a96b1e78cc48bf254f5ea4b5b85efaf9e9e2a526b3c9309d660ca",
-                "sha256:665b21e95bc0fce5cab03b2e1d90ba9c66c510f1bb5fdc864f3a377d0f553f6b",
-                "sha256:6a4bf607f690f7987ab3291406e012cd8591a4f77aa54f29b890f9c331e84989",
-                "sha256:6cea1cca3be76c9483282dc7760ea1cc08a6ecec1f0b6ca0a94ea0d17432da19",
-                "sha256:713d450cf8e61854de9420fb7eea8ad228df4e27e7d4ed465de98c955d2b3fa6",
-                "sha256:726377bd60081172685c0ff46afbc600d064f01053190e4450857483c4d44484",
-                "sha256:76b3e3976d2a452cba7aa9e453498ac72240d43030fdc6d538a72b87eaff52fd",
-                "sha256:76dc19e660baea5c38e949455c1181bc018893f25372d10ffe24b3ed7341fb25",
-                "sha256:76e5064fd8e94c3f74d9fd69b02d99e3cdb8fc286ed49a1f10b256e59d0d3a0b",
-                "sha256:7f346d24d74c00b6730440f5eb8ec3fe5774ca8d1c9574e8e57c8671bb51b910",
-                "sha256:81eeec4403a7d7684b5812a8aaa626fa23b7d0848edb3a28d2eb3220daddcbd0",
-                "sha256:90b5bbf05fe3d3ef697103850c2ce3374558f6fe40fd57c9fac1bf14903f50a5",
-                "sha256:9730929375021ec90f6447bff4f7f5508faef1c02f399a1953870cdb78e0c345",
-                "sha256:9eb4a1d7399b9f3c7ac68ae6baa6be5f9195d1d08c9ddc45ad559aa6b556bce6",
-                "sha256:a0409bc18a9f85321399c29baf93545152d74a49d92f2f55302f122007cfda00",
-                "sha256:a22f4e26400f7f48faef2d69c20dc055a1f3043d330923f9abe08ea0aecc44df",
-                "sha256:a53dfe8f82b715319e9953330fa5c8708b610d48b5c59f1316337302af5c0811",
-                "sha256:a771dc64fa44ebe58d65768d869fcfb9060169d203446c1d446e844b62bdfdca",
-                "sha256:a814dc3100e8a046ff48faeaa909e80cdb358411a3d6dd5293158425c684eda8",
-                "sha256:a8870983af660798dc1b529e1fd6f1cefd94e45135a32e58bd70edd694540f33",
-                "sha256:ac0adfdb3a21dc2a24ed728b61e72440d297d0fd3a577389df566651fcd08f97",
-                "sha256:b395121e9bbe8d02a750886f108d540abe66075e61e22f7353d9acb0b81be0f0",
-                "sha256:b9505a0c8579899057cbefd4ec34d865ab99852baf1ff33a9481eb3924e2da0b",
-                "sha256:c0a5b1c22c82831f56f2f7ad9bbe4948879762fe0d59833a4a71f16e5fa0f682",
-                "sha256:c3967dcc1cd2ea61b08b0b276659242cbce5caca39e7cbc02408222fb9e6ff39",
-                "sha256:c6f4c2027689093775fd58ca2388d58789009116844432d920e9147f91acbe64",
-                "sha256:c9d86401550b09a55410f32ceb5fe7efcd998bd2dad9e82521713cb148a4a15f",
-                "sha256:cd468ec62257bb4544989402b19d795d2305eccb06cde5da0eb739b63dc04665",
-                "sha256:cfcfb73aed40f550a57ea904629bdaf2e562c68fa1164fa4588e752af6efdc3f",
-                "sha256:d0dd943282231480aad5f50f89bdf26690c995e8ff555f26d8a5b9887b559bcc",
-                "sha256:d3c59a06c2c28a81a026ff11fbf012081ea34fb9b7052f2ed0366e14896f0a1d",
-                "sha256:d45b75b0f3fd8d99f62eb7908cfa6d727b7ed190737dec7fe46d993da550b81a",
-                "sha256:d46d5069e2eeda111d6f71970e341f4bd9aeeee92074e649ae263b834286ecc0",
-                "sha256:d58ec349e0c2c0bc6669bf2cd4982d2f93bf067860d23a0ea1fe677b0f0b1e09",
-                "sha256:db1b3ccb93488328c74e97ff888604a8b95ae4f35f4f56677ca57a4fc3a4220b",
-                "sha256:dd65695a8df1233309b701dec2539cc4b11e97d4fcc0f4185b4a12ce54db0491",
-                "sha256:f9482c2ed414781c0af0b35d9d575226da6b728bd1a720668fa05837184965b7",
-                "sha256:f9671e7282d8c6fcabc32c0fb8d7c0ea8894ae85cee89c9aadc2d7129e1a9954",
-                "sha256:fad7a051e07f64e297e6e8399b4d6a3bdcad3d7297409e9a06ef8cbccff4f501",
-                "sha256:ffb08f2a1e59d38c7b8b9ac8083c9c8b9875f0955b1e9b9b9a965607a51f8e54"
+                "sha256:0153404a4bb921f0ff1abeb5ce8a5131da56b953eda6e14b88dc6bbc04d2049e",
+                "sha256:03a088b9de532cbfe2ba2034b2b85e82df37874681e8c470d6fb2f8c04d7e4b7",
+                "sha256:04b013dc07c96f83134b1e99888e7a79979f1a247e2a9f59697fa14b5862ed01",
+                "sha256:05175c27cb459dcfc05d026c4232f9de8913ed006d42713cb8a5137bd49375f1",
+                "sha256:09fc016b73c94e98e29af67ab7b9a879c307c6731a2c9da0db5a7d9b7edd1159",
+                "sha256:0bbae94a29c9e5c7e4a2b7f0aae5c17e8e90acbfd3bf6270eeba60c39fce3563",
+                "sha256:0fde093fb93f35ca72a556cf72c92ea3ebfda3d79fc35bb19fbe685853869a83",
+                "sha256:1443279c19fca463fc33e65ef2a935a5b09bb90f978beab37729e1c3c6c25fe9",
+                "sha256:1776fd7f989fc6b8d8c8cb8da1f6b82c5814957264d1f6cf818d475ec2bf6395",
+                "sha256:1d3755bcb2e02de341c55b4fca7a745a24a9e7212ac953f6b3a48d117d7257aa",
+                "sha256:23f20bb60ae298d7d8656c6ec6db134bca379ecefadb0b19ce6f19d1f232a942",
+                "sha256:275f72decf9932639c1c6dd1013a1bc266438eb32710016a1c742df5da6e60a1",
+                "sha256:2846930c65b47d70b9d178e89c7e1a69c95c1f68ea5aa0a58646b7a96df12441",
+                "sha256:3319aa75e0e0639bc15ff54ca327e8dc7a6fe404003496e3c6925cd3142e0e22",
+                "sha256:346bed03fe47414091be4ad44786d1bd8bef0c3fcad6ed3dee074a032ab408a9",
+                "sha256:36b89d13c49216cadb828db8dfa6ce86bbbc476a82d3a6c397f0efae0525bdd0",
+                "sha256:37b9de5a96111fc15418819ab4c4432e4f3c2ede61e660b1e33971eba26ef9ba",
+                "sha256:396979749bd95f018296af156201d6211240e7a23090f50a8d5d18c370084dc3",
+                "sha256:3b2813dc3de8c1ee3f924e4d4227999285fd335d1bcc0d2be6dc3f1f6a318ec1",
+                "sha256:411f015496fec93c1c8cd4e5238da364e1da7a124bcb293f085bf2860c32c6f6",
+                "sha256:47da355d8687fd65240c364c90a31569a133b7b60de111c255ef5b606f2ae291",
+                "sha256:48ca08c771c268a768087b408658e216133aecd835c0ded47ce955381105ba39",
+                "sha256:4afe7ea89de619adc868e087b4d2359282058479d7cfb94970adf4b55284574d",
+                "sha256:4ce3ac6cdb6adf7946475d7ef31777c26d94bccc377e070a7986bd2d5c515467",
+                "sha256:4ead44c85f8ab905852d3de8d86f6f8baf77109f9da589cb4fa142bd3b57b475",
+                "sha256:54558ea205654b50c438029505def3834e80f0869a70fb15b871c29b4575ddef",
+                "sha256:5e06afd14cbaf9e00899fae69b24a32f2196c19de08fcb9f4779dd4f004e5e7c",
+                "sha256:62ee94988d6b4722ce0028644418d93a52429e977d742ca2ccbe1c4f4a792511",
+                "sha256:63e4844797b975b9af3a3fb8f7866ff08775f5426925e1e0bbcfe7932059a12c",
+                "sha256:6510bf84a6b643dabba74d3049ead221257603a253d0a9873f55f6a59a65f822",
+                "sha256:667a9706c970cb552ede35aee17339a18e8f2a87a51fba2ed39ceeeb1004798a",
+                "sha256:6ef9ea3f137e5711f0dbe5f9263e8c009b7069d8a1acea822bd5e9dae0ae49c8",
+                "sha256:7017b2be767b9d43cc31416aba48aab0d2309ee31b4dbf10a1d38fb7972bdf9d",
+                "sha256:7124e16b4c55d417577c2077be379514321916d5790fa287c9ed6f23bd2ffd01",
+                "sha256:73aaad12ac0ff500f62cebed98d8789198ea0e6f233421059fa68a5aa7220145",
+                "sha256:77c386de38a60d1dfb8e55b8c1101d68c79dfdd25c7095d51fec2dd800892b80",
+                "sha256:7876452af029456b3f3549b696bb36a06db7c90747740c5302f74a9e9fa14b13",
+                "sha256:7939aa3ca7d2a1593596e7ac6d59391ff30281ef280d8632fa03d81f7c5f955e",
+                "sha256:8320f64b777d00dd7ccdade271eaf0cad6636343293a25074cc5566160e4de7b",
+                "sha256:85f3ff71e2e60bd4b4932a043fbbe0f499e263c628390b285cb599154a3b03b1",
+                "sha256:8b8b36671f10ba80e159378df9c4f15c14098c4fd73a36b9ad715f057272fbef",
+                "sha256:93147c513fac16385d1036b7e5b102c7fbbdb163d556b791f0f11eada7ba65dc",
+                "sha256:935e943ec47c4afab8965954bf49bfa639c05d4ccf9ef6e924188f762145c0ff",
+                "sha256:94b6150a85e1b33b40b1464a3f9988dcc5251d6ed06842abff82e42632fac120",
+                "sha256:94ebba31df2aa506d7b14866fed00ac141a867e63143fe5bca82a8e503b36437",
+                "sha256:95ffcf719966dd7c453f908e208e14cde192e09fde6c7186c8f1896ef778d8cd",
+                "sha256:98884ecf2ffb7d7fe6bd517e8eb99d31ff7855a840fa6d0d63cd07c037f6a981",
+                "sha256:99cfaa2110534e2cf3ba31a7abcac9d328d1d9f1b95beede58294a60348fba36",
+                "sha256:9e8f8c9cb53cdac7ba9793c276acd90168f416b9ce36799b9b885790f8ad6c0a",
+                "sha256:a0dfc6c143b519113354e780a50381508139b07d2177cb6ad6a08278ec655798",
+                "sha256:b2795058c23988728eec1f36a4e5e4ebad22f8320c85f3587b539b9ac84128d7",
+                "sha256:b42703b1cf69f2aa1df7d1030b9d77d3e584a70755674d60e710f0af570f3761",
+                "sha256:b7cede291382a78f7bb5f04a529cb18e068dd29e0fb27376074b6d0317bf4dd0",
+                "sha256:b8a678974d1f3aa55f6cc34dc480169d58f2e6d8958895d68845fa4ab566509e",
+                "sha256:b8da394b34370874b4572676f36acabac172602abf054cbc4ac910219f3340af",
+                "sha256:c3a701fe5a9695b238503ce5bbe8218e03c3bcccf7e204e455e7462d770268aa",
+                "sha256:c4aab7f6381f38a4b42f269057aee279ab0fc7bf2e929e3d4abfae97b682a12c",
+                "sha256:ca9d0ff5ad43e785350894d97e13633a66e2b50000e8a183a50a88d834752d42",
+                "sha256:d0028e725ee18175c6e422797c407874da24381ce0690d6b9396c204c7f7276e",
+                "sha256:d21e10da6ec19b457b82636209cbe2331ff4306b54d06fa04b7c138ba18c8a81",
+                "sha256:d5e975ca70269d66d17dd995dafc06f1b06e8cb1ec1e9ed54c1d1e4a7c4cf26e",
+                "sha256:da7a9bff22ce038e19bf62c4dd1ec8391062878710ded0a845bcf47cc0200617",
+                "sha256:db32b5348615a04b82240cc67983cb315309e88d444a288934ee6ceaebcad6cc",
+                "sha256:dcc62f31eae24de7f8dce72134c8651c58000d3b1868e01392baea7c32c247de",
+                "sha256:dfc59d69fc48664bc693842bd57acfdd490acafda1ab52c7836e3fc75c90a111",
+                "sha256:e347b3bfcf985a05e8c0b7d462ba6f15b1ee1c909e2dcad795e49e91b152c383",
+                "sha256:e4d333e558953648ca09d64f13e6d8f0523fa705f51cae3f03b5983489958c70",
+                "sha256:ed10eac5830befbdd0c32f83e8aa6288361597550ba669b04c48f0f9a2c843c6",
+                "sha256:efc0f674aa41b92da8c49e0346318c6075d734994c3c4e4430b1c3f853e498e4",
+                "sha256:f1695e76146579f8c06c1509c7ce4dfe0706f49c6831a817ac04eebb2fd02011",
+                "sha256:f1d4aeb8891338e60d1ab6127af1fe45def5259def8094b9c7e34690c8858803",
+                "sha256:f406b22b7c9a9b4f8aa9d2ab13d6ae0ac3e85c9a809bd590ad53fed2bf70dc79",
+                "sha256:f6ff3b14f2df4c41660a7dec01045a045653998784bf8cfcb5a525bdffffbc8f"
             ],
             "markers": "python_version < '3.13' and (platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32'))))))",
-            "version": "==3.1.0"
+            "version": "==3.1.1"
         },
         "iniconfig": {
             "hashes": [
@@ -484,21 +491,21 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:02f4aedeac91be69fb3b4bea997ce580a4ac68ce58b89eaefeaf06749df73f4b",
-                "sha256:1b7a721b575eaeaa7d39db076b6e7743c993ea44f57979127c517c6c572c803e"
+                "sha256:2f846a466dd023513240bc140ad2dd73bfc080a5d85a710afdb728c420a5a2b9",
+                "sha256:9f3dcc87b1203e612b78d91a896407787e708b3f189b5fa0b307712d49ff0c6e"
             ],
             "index": "pypi",
-            "markers": "python_full_version >= '3.8.0'",
-            "version": "==3.2.7"
+            "markers": "python_full_version >= '3.9.0'",
+            "version": "==3.3.1"
         },
         "pyright": {
             "hashes": [
-                "sha256:314cf0c1351c189524fb10c7ac20688ecd470e8cc505c394d642c9c80bf7c3a5",
-                "sha256:5dc0aa80a265675d36abab59c674ae01dbe476714f91845b61b841d34aa99081"
+                "sha256:1df7f12407f3710c9c6df938d98ec53f70053e6c6bbf71ce7bcb038d42f10070",
+                "sha256:d864d1182a313f45aaf99e9bfc7d2668eeabc99b29a556b5344894fd73cb1959"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==1.1.381"
+            "version": "==1.1.383"
         },
         "pytest": {
             "hashes": [
@@ -517,6 +524,15 @@
             "index": "pypi",
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==0.4.27"
+        },
+        "python-magic-bin": {
+            "hashes": [
+                "sha256:34a788c03adde7608028203e2dbb208f1f62225ad91518787ae26d603ae68892",
+                "sha256:7b1743b3dbf16601d6eedf4e7c2c9a637901b0faaf24ad4df4d4527e7d8f66a4",
+                "sha256:90be6206ad31071a36065a2fc169c5afb5e0355cbe6030e87641c6c62edc2b69"
+            ],
+            "index": "pypi",
+            "version": "==0.4.14"
         },
         "python-string-utils": {
             "hashes": [

--- a/server/app.py
+++ b/server/app.py
@@ -14,7 +14,7 @@ from vars import LOG_LEVEL
 logging.basicConfig(format="%(levelname)s:%(message)s", level=LOG_LEVEL)
 
 
-def create_app(csrf: CSRFProtect, db: SQLAlchemy):
+def create_app(csrf: CSRFProtect, db: SQLAlchemy, db_uri="sqlite:///db.sqlite3"):
     """
     Create the app instance, register all URLs and the database to the app
     """
@@ -27,7 +27,7 @@ def create_app(csrf: CSRFProtect, db: SQLAlchemy):
     import media.media_api
 
     app = Flask(__name__, static_folder="../web/dist")
-    app.config["SQLALCHEMY_DATABASE_URI"] = os.getenv("DATABASE_URI", "sqlite:///db.sqlite3")
+    app.config["SQLALCHEMY_DATABASE_URI"] = os.getenv("DATABASE_URI", db_uri)
     app.config["SECRET_KEY"] = os.getenv('SECRET_KEY', 'default-not-so-secret-secret-key')
     app.config["JWT_SECRET_KEY"] = os.getenv('SECRET_KEY', 'default-not-so-secret-secret-key')
     app.config['WTF_CSRF_CHECK_DEFAULT'] = False

--- a/server/conftest.py
+++ b/server/conftest.py
@@ -1,6 +1,7 @@
 import jwt
 import pytest
 
+import dbsetup
 from app import create_app
 from app_config import csrf, db
 from execution import run
@@ -13,33 +14,93 @@ You can add code before and after the yield to set up and tear down other resour
 database.
 """
 
-flask_app = create_app(csrf=csrf, db=db)
-
+# Create a Flask app with an in-memory SQLite database for testing
+flask_app = create_app(csrf=csrf, db=db, db_uri='sqlite:///:memory:')
 
 @pytest.fixture()
-def app():
-
-    # Set up
+def fully_setup_app():
+    """
+    Configures a python app with in memory database. Further the dummy entities are loaded in memory.
+    """
+    # Configure testing mode
     flask_app.config.update({
         "TESTING": True,
     })
+
+    # Create the database tables
+    with flask_app.app_context():
+        db.create_all()  # Create all tables for testing
+        dbsetup.db_setup(app=flask_app, database=db)
+
+    # Activate dummy executions
     run.activate_execution(dummy_entities.create_test_execution())
     run.activate_execution(dummy_entities.create_test_execution(pending=False))
 
     yield flask_app
 
     # Clean up
+    with flask_app.app_context():
+        db.session.remove()  # Remove the session
+        db.drop_all()  # Drop all tables after the tests
+
+    run.active_executions = {}
+
+@pytest.fixture()
+def db_app():
+    """
+    Configures a python app with in memory database only.
+    """
+    # Configure testing mode
+    flask_app.config.update({
+        "TESTING": True,
+    })
+
+    # Create the database tables
+    with flask_app.app_context():
+        db.create_all()  # Create all tables for testing
+        dbsetup.db_setup(app=flask_app, database=db)
+
+    yield flask_app
+
+    # Clean up
+    with flask_app.app_context():
+        db.session.remove()  # Remove the session
+        db.drop_all()  # Drop all tables after the tests
+
+@pytest.fixture()
+def entity_app():
+    """
+    The dummy entities are loaded in memory.
+    """
+    # Configure testing mode
+    flask_app.config.update({
+        "TESTING": True,
+    })
+
+    # Activate dummy executions
+    run.activate_execution(dummy_entities.create_test_execution())
+    run.activate_execution(dummy_entities.create_test_execution(pending=False))
+
+    yield flask_app
+
     run.active_executions = {}
 
 
-@pytest.fixture()
-def client(app):
-    return app.test_client()
-
 
 @pytest.fixture()
-def runner(app):
-    return app.test_cli_runner()
+def api_client(entity_app):
+    """ Returns a flask app with preloaded dummy-entities. """
+    return entity_app.test_client()
+
+@pytest.fixture()
+def web_client(db_app):
+    """ Returns a flask app with preloaded database. """
+    return db_app.test_client()
+
+@pytest.fixture()
+def fully_setup_client(fully_setup_app):
+    """ Returns a flask app with preloaded database and dummy-entities. """
+    return fully_setup_app.test_client()
 
 
 def generate_token(app, valid_payload=True, pending=False, plid="123ABC"):

--- a/server/dbsetup.py
+++ b/server/dbsetup.py
@@ -613,7 +613,7 @@ def __create_activity_diagrams():
     return acd1, acd2, acd3, acd4, acd5
 
 
-def db_setup(app: Flask = None, database: SQLAlchemy| None = None):
+def db_setup(app: Flask| None = None, database: SQLAlchemy| None = None):
     if not app:
         app = create_app(csrf=csrf, db=database)
     if not database:

--- a/server/dbsetup.py
+++ b/server/dbsetup.py
@@ -1,6 +1,9 @@
+import logging
 import uuid
 
 from bcrypt import gensalt, hashpw
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
 
 from app import create_app
 from app_config import db, csrf
@@ -610,30 +613,40 @@ def __create_activity_diagrams():
     return acd1, acd2, acd3, acd4, acd5
 
 
-with create_app(csrf=csrf, db=db).app_context():
-    __create_scenarios()
-    __create_executions()
-    __create_roles()
-    __create_patients()
-    __create_locations()
-    __create_players()
-    __create_resources()
-    __create_actions()
-    __resource_needed()
-    __patient_in_scenario()
+def db_setup(app: Flask = None, database: SQLAlchemy = None):
+    if not app:
+        app = create_app(csrf=csrf, db=database)
+    if not database:
+        logging.error("Empty database object provided. Unable to setup database.")
+        return
 
-    insert(WebUser(username="wadmin",
-                   password=hashpw(b"pw1234", gensalt()).decode(),
-                   role=WebUser.Role.WEB_ADMIN.name))
+    with app.app_context():
+        __create_scenarios()
+        __create_executions()
+        __create_roles()
+        __create_patients()
+        __create_locations()
+        __create_players()
+        __create_resources()
+        __create_actions()
+        __resource_needed()
+        __patient_in_scenario()
 
-    insert(WebUser(username="sadmin",
-                   password=hashpw(b"pw1234", gensalt()).decode(),
-                   role=WebUser.Role.SCENARIO_ADMIN.name))
+        insert(WebUser(username="wadmin",
+                       password=hashpw(b"pw1234", gensalt()).decode(),
+                       role=WebUser.Role.WEB_ADMIN.name))
 
-    insert(WebUser(username="gmaster",
-                   password=hashpw(b"pw1234", gensalt()).decode(),
-                   role=WebUser.Role.GAME_MASTER.name))
+        insert(WebUser(username="sadmin",
+                       password=hashpw(b"pw1234", gensalt()).decode(),
+                       role=WebUser.Role.SCENARIO_ADMIN.name))
 
-    insert(WebUser(username="read",
-                   password=hashpw(b"pw1234", gensalt()).decode(),
-                   role=WebUser.Role.READ_ONLY.name))
+        insert(WebUser(username="gmaster",
+                       password=hashpw(b"pw1234", gensalt()).decode(),
+                       role=WebUser.Role.GAME_MASTER.name))
+
+        insert(WebUser(username="read",
+                       password=hashpw(b"pw1234", gensalt()).decode(),
+                       role=WebUser.Role.READ_ONLY.name))
+
+if __name__ == "__main__":
+    db_setup(database=db)

--- a/server/dbsetup.py
+++ b/server/dbsetup.py
@@ -614,11 +614,11 @@ def __create_activity_diagrams():
 
 
 def db_setup(app: Flask| None = None, database: SQLAlchemy| None = None):
-    if not app:
-        app = create_app(csrf=csrf, db=database)
     if not database:
         logging.error("Empty database object provided. Unable to setup database.")
         return
+    if not app:
+        app = create_app(csrf=csrf, db=database)
 
     with app.app_context():
         __create_scenarios()

--- a/server/dbsetup.py
+++ b/server/dbsetup.py
@@ -613,7 +613,7 @@ def __create_activity_diagrams():
     return acd1, acd2, acd3, acd4, acd5
 
 
-def db_setup(app: Flask = None, database: SQLAlchemy = None):
+def db_setup(app: Flask = None, database: SQLAlchemy| None = None):
     if not app:
         app = create_app(csrf=csrf, db=database)
     if not database:

--- a/server/execution/tests/api/test_lobby.py
+++ b/server/execution/tests/api/test_lobby.py
@@ -8,7 +8,7 @@ execution_ids = run.active_executions.keys()
 player_ids = run.registered_players.keys()
 
 
-def test_active_player(client):
+def test_active_player(api_client):
     invalid_tan = "-1f"
     form = {
         "TAN": list(player_ids)[-1]
@@ -16,7 +16,7 @@ def test_active_player(client):
     headers = {
         "Content-Type": "application/json"
     }
-    response = client.post(f"/api/login", data=json.dumps(form), headers=headers)
+    response = api_client.post(f"/api/login", data=json.dumps(form), headers=headers)
     assert response.status_code == 200
     assert response.json["jwt_token"] != ""
     assert response.json["csrf_token"] != ""
@@ -24,51 +24,51 @@ def test_active_player(client):
     form = {
         "TAN": invalid_tan
     }
-    response = client.post(f"/api/login", json.dumps(form), headers=headers)
+    response = api_client.post(f"/api/login", json.dumps(form), headers=headers)
     assert response.status_code == 400
 
 
-def test_current_exec_status(client):
+def test_current_exec_status(api_client):
     execution_id = list(execution_ids)[-1]
     test_execution: Execution = run.active_executions[execution_id]
-    headers = generate_token(client.application, pending=True)
-    headers_invalid_payload = generate_token(client.application, valid_payload=False)
+    headers = generate_token(api_client.application, pending=True)
+    headers_invalid_payload = generate_token(api_client.application, valid_payload=False)
 
     # status independent check
-    response = client.get("/api/scenario/start-time", headers=headers)
+    response = api_client.get("/api/scenario/start-time", headers=headers)
     assert response.status_code == 204
 
     # status is RUNNING
-    headers = generate_token(client.application)
-    response = client.get("/api/scenario/start-time", headers=headers)
+    headers = generate_token(api_client.application)
+    response = api_client.get("/api/scenario/start-time", headers=headers)
     assert response.status_code == 200
     assert response.json["starting_time"] == test_execution.starting_time
 
     assert response.json["arrival_time"] > run.active_executions[2].players["654WVU"].activation_delay_sec
 
     # invalid id
-    response = client.get("/api/scenario/start-time", headers=headers_invalid_payload)
+    response = api_client.get("/api/scenario/start-time", headers=headers_invalid_payload)
     assert response.status_code == 400
 
 
-def test_set_name(client):
+def test_set_name(api_client):
     player_id = "123ABC"
     exec_id = run.registered_players[player_id]
     execution = run.active_executions[exec_id]
     player = execution.players[player_id]
 
-    auth_header = generate_token(client.application, pending=True)
+    auth_header = generate_token(api_client.application, pending=True)
     auth_header["Content-Type"] = "application/json"
     # initial set-name
     form = {
         "name": "Test-User"
     }
-    response = client.post("/api/player/set-name", data=json.dumps(form), headers=auth_header)
+    response = api_client.post("/api/player/set-name", data=json.dumps(form), headers=auth_header)
     assert response.status_code == 200
     assert player.name == "Test-User"
 
     # invalid set-name due to already existing string
-    response = client.post("/api/player/set-name", data=json.dumps(form), headers=auth_header)
+    response = api_client.post("/api/player/set-name", data=json.dumps(form), headers=auth_header)
     assert response.status_code == 409
 
     # forcing the set name to succeed
@@ -76,7 +76,7 @@ def test_set_name(client):
         "name": "Test-User-v2",
         "force_update": "True"
     }
-    response = client.post("/api/player/set-name", data=json.dumps(form), headers=auth_header)
+    response = api_client.post("/api/player/set-name", data=json.dumps(form), headers=auth_header)
     assert response.status_code == 200
 
     # set wrong force flag
@@ -84,7 +84,7 @@ def test_set_name(client):
         "name": "Test-User-v3",
         "force_update": "False"
     }
-    response = client.post("/api/player/set-name", data=json.dumps(form), headers=auth_header)
+    response = api_client.post("/api/player/set-name", data=json.dumps(form), headers=auth_header)
     assert response.status_code == 409
 
     # set invalid force key with True
@@ -92,14 +92,14 @@ def test_set_name(client):
         "name": "Test-User-v4",
         "force_update-invalid-key": "True"
     }
-    response = client.post("/api/player/set-name", data=json.dumps(form), headers=auth_header)
+    response = api_client.post("/api/player/set-name", data=json.dumps(form), headers=auth_header)
     assert response.status_code == 409
 
     # invalid name key
     form = {
         "name-invalid-key": "Test-User-v5"
     }
-    response = client.post("/api/player/set-name", data=json.dumps(form), headers=auth_header)
+    response = api_client.post("/api/player/set-name", data=json.dumps(form), headers=auth_header)
     assert response.status_code == 400
 
     assert player.name == "Test-User-v2"

--- a/server/execution/tests/api/test_location.py
+++ b/server/execution/tests/api/test_location.py
@@ -4,21 +4,21 @@ from http import HTTPStatus
 from conftest import generate_token
 
 
-def test_player_inventory(client):
-    auth_header = generate_token(client.application)
+def test_player_inventory(api_client):
+    auth_header = generate_token(api_client.application)
 
-    response = client.get("/api/run/player/inventory", headers=auth_header)
+    response = api_client.get("/api/run/player/inventory", headers=auth_header)
     response_data = response.get_json()
     assert response.status_code == 200
     assert len(response_data["accessible_locations"]) > 0
 
 
-def test_put_without_player_location(client):
-    headers = generate_token(client.application)
+def test_put_without_player_location(fully_setup_client):
+    headers = generate_token(fully_setup_client.application)
     headers["Content-Type"] = "application/json"
 
     # leave location
-    response = client.post("/api/run/location/leave", headers=headers)
+    response = fully_setup_client.post("/api/run/location/leave", headers=headers)
     assert response.status_code == HTTPStatus.OK
 
     form = {
@@ -26,14 +26,14 @@ def test_put_without_player_location(client):
         "to_location_ids": "[5]"
     }
 
-    response = client.post("/api/run/location/put-to", headers=headers,
+    response = fully_setup_client.post("/api/run/location/put-to", headers=headers,
                            data=json.dumps(form))
     assert response.status_code == HTTPStatus.OK
 
 
-def ttest_put_toplevel_inventory_location(client):
+def ttest_put_toplevel_inventory_location(fully_setup_client):
     # Disabled, because the test has IDE debugger use only.
-    headers = generate_token(client.application)
+    headers = generate_token(fully_setup_client.application)
     headers["Content-Type"] = "application/json"
 
     form = {
@@ -41,10 +41,10 @@ def ttest_put_toplevel_inventory_location(client):
         "to_location_ids": "[5]"
     }
 
-    response = client.post("/api/run/location/put-to", headers=headers,
+    response = fully_setup_client.post("/api/run/location/put-to", headers=headers,
                            data=json.dumps(form))
     assert response.status_code == HTTPStatus.OK
-    response_inventory = client.get("/api/run/player/inventory",
+    response_inventory = fully_setup_client.get("/api/run/player/inventory",
                                     headers=headers)
     assert response_inventory.status_code == HTTPStatus.OK
 

--- a/server/execution/tests/api/test_notification.py
+++ b/server/execution/tests/api/test_notification.py
@@ -2,15 +2,15 @@ from execution import run
 from conftest import generate_token
 
 
-def test_get_notifications(client):
-    auth_header = generate_token(client.application)
+def test_get_notifications(api_client):
+    auth_header = generate_token(api_client.application)
     execution = run.active_executions[2]
 
     messageA = "I am the first test-message."
     messageB = "I am the second test-message."
     messageC = "Why do we count test-messages. I am different."
 
-    response = client.get("/api/notifications?next_id=0", headers=auth_header)
+    response = api_client.get("/api/notifications?next_id=0", headers=auth_header)
     assert response.status_code == 204
 
     execution.notifications.append(
@@ -25,16 +25,16 @@ def test_get_notifications(client):
         }
     )
 
-    response = client.get("/api/notifications")
+    response = api_client.get("/api/notifications")
     assert response.status_code == 401
 
-    response = client.get("/api/notifications", headers=auth_header)
+    response = api_client.get("/api/notifications", headers=auth_header)
     assert response.status_code == 400
 
-    response = client.get("/api/notifications?next_id=200", headers=auth_header)
+    response = api_client.get("/api/notifications?next_id=200", headers=auth_header)
     assert response.status_code == 418
 
-    response = client.get("/api/notifications?next_id=0", headers=auth_header)
+    response = api_client.get("/api/notifications?next_id=0", headers=auth_header)
     assert response.status_code == 200
     data = response.json
     assert len(data["notifications"]) == 2
@@ -49,7 +49,7 @@ def test_get_notifications(client):
             "timestamp": "empty"
         }
     )
-    response = client.get("/api/notifications?next_id=2", headers=auth_header)
+    response = api_client.get("/api/notifications?next_id=2", headers=auth_header)
     assert response.status_code == 200
     data = response.json
     assert len(data["notifications"]) == 1

--- a/server/execution/tests/api/test_setup.py
+++ b/server/execution/tests/api/test_setup.py
@@ -1,21 +1,21 @@
 from conftest import generate_token
 
 
-def test_request_on_pending_execution(client):
-    auth_header = generate_token(app=client.application, pending=True)
+def test_request_on_pending_execution(api_client):
+    auth_header = generate_token(app=api_client.application, pending=True)
 
-    response = client.get("/api/run/action/all", headers=auth_header)
+    response = api_client.get("/api/run/action/all", headers=auth_header)
     assert response.status_code == 204
-    response = client.get("/api/run/location/all", headers=auth_header)
+    response = api_client.get("/api/run/location/all", headers=auth_header)
     assert response.status_code == 204
-    response = client.get("/api/run/patient/all-ids", headers=auth_header)
+    response = api_client.get("/api/run/patient/all-ids", headers=auth_header)
     assert response.status_code == 204
 
-    auth_header = generate_token(app=client.application)
+    auth_header = generate_token(app=api_client.application)
 
-    response = client.get("/api/run/action/all", headers=auth_header)
+    response = api_client.get("/api/run/action/all", headers=auth_header)
     assert response.status_code == 200
-    response = client.get("/api/run/location/all", headers=auth_header)
+    response = api_client.get("/api/run/location/all", headers=auth_header)
     assert response.status_code == 200
-    response = client.get("/api/run/patient/all-ids", headers=auth_header)
+    response = api_client.get("/api/run/patient/all-ids", headers=auth_header)
     assert response.status_code == 200

--- a/server/execution/tests/entities/test_location.py
+++ b/server/execution/tests/entities/test_location.py
@@ -15,7 +15,7 @@ def test_timeout():
     l.loc_lock.release()
 
 
-def test_leave_location(client):
+def test_leave_location(api_client):
     # Setup
     execution = run.active_executions[2]
     locations = list(execution.scenario.locations.values())

--- a/server/execution/tests/entities/test_resource.py
+++ b/server/execution/tests/entities/test_resource.py
@@ -6,7 +6,7 @@ from execution.entities.resource import Resource
 from utils import time as utime
 
 
-def test_decrease(client):
+def test_decrease():
     resource = Resource(id=1, name="test", quantity=10000, media_references=[])
 
     # test infinite
@@ -38,7 +38,7 @@ def test_decrease(client):
     assert resource.locked_until > current_secs
 
 
-def test_increase_decrease(client):
+def test_increase_decrease():
     quantity = 50
     resource = Resource(1, "test", quantity, [])
     resource.consumable = False

--- a/server/execution/tests/services/test_entityloader.py
+++ b/server/execution/tests/services/test_entityloader.py
@@ -1,6 +1,5 @@
 import models
 from app_config import db
-from conftest import flask_app
 from execution import run
 from execution.entities.execution import Execution
 from execution.entities.location import Location
@@ -136,12 +135,12 @@ def _check_actions(scenario: Scenario):
             else db_action.results is None
 
 
-def test_load_execution():
+def test_load_execution(db_app):
     # Clear state before actual test
     run.active_executions = {}
     run.registered_players = {}
 
-    with flask_app.app_context():
+    with db_app.app_context():
         # Load Executions from DB
         db_execs = db.session.query(models.Execution).all()
         for ex in db_execs:

--- a/server/execution/tests/web_api/test_lobby.py
+++ b/server/execution/tests/web_api/test_lobby.py
@@ -8,22 +8,22 @@ Tests are deactivated, because they are designed for Debugging Cases in IDE.
 They are not appliable for pipeline.
 """
 
-def ttest_create_execution(client):
-    auth_header = generate_webtoken(client.application)
+def ttest_create_execution(web_client):
+    auth_header = generate_webtoken(web_client.application)
     form_data = {
         "scenario_id": 1,
         "name": "test"
     }
-    with client.application.app_context():
+    with web_client.application.app_context():
         patient_to_vehicle = models.PlayersToVehicleInExecution.query.all()
         assert patient_to_vehicle
-    response = client.post("/web/execution/create", headers=auth_header, data=form_data)
+    response = web_client.post("/web/execution/create", headers=auth_header, data=form_data)
     assert response
 
 
-def ttest_execution_state_change(client):
+def ttest_execution_state_change(web_client):
     """ Tests the execution state changes of the lobby patch method. """
-    auth_header = generate_webtoken(client.application)
+    auth_header = generate_webtoken(web_client.application)
 
     # PER DEFAULT
     # id=1 PENDING
@@ -37,7 +37,7 @@ def ttest_execution_state_change(client):
             else:
                 status_before = Execution.Status.UNKNOWN
             # test illegal state changes
-            response = client.patch(f"/web/execution?id={exec_id}",
+            response = web_client.patch(f"/web/execution?id={exec_id}",
                                     headers=auth_header,
                                     data={"new_status": unwanted_status})
 
@@ -50,7 +50,7 @@ def ttest_execution_state_change(client):
 
     def _test_legal_state_changes(exec_id, wanted_status_list):
         for wanted_status in wanted_status_list:
-            response = client.patch(f"/web/execution?id={exec_id}",
+            response = web_client.patch(f"/web/execution?id={exec_id}",
                                     headers=auth_header,
                                     data={"new_status": wanted_status})
             assert response.status_code == 200

--- a/server/media/tests/test_media_api.py
+++ b/server/media/tests/test_media_api.py
@@ -9,41 +9,41 @@ TEST_IMG_1 = "media/static/image/rucksack_rot.jpg"
 TEST_IMG_2 = "media/static/image/tasche_rot.jpg"
 
 
-def test_get_static_media(client):
+def test_get_static_media(api_client):
     # Test Image 1
-    response = client.get(TEST_IMG_1)
+    response = api_client.get(TEST_IMG_1)
     assert response.status_code == http.HTTPStatus.OK
     # Test Image 2
-    response = client.get(TEST_IMG_2)
+    response = api_client.get(TEST_IMG_2)
     assert response.status_code == http.HTTPStatus.OK
 
 
-def test_post_instance_media_file(client):
+def test_post_instance_media_file(api_client):
     # Disable CSRF for this test
-    client.application.config['WTF_CSRF_METHODS'] = []
+    api_client.application.config['WTF_CSRF_METHODS'] = []
 
-    auth_header = generate_webtoken(client.application, WebUser.Role.SCENARIO_ADMIN)
+    auth_header = generate_webtoken(api_client.application, WebUser.Role.SCENARIO_ADMIN)
 
     # Test post image
     with open(TEST_IMG_1, 'rb') as image_file:
         data = {
             "file": (io.BytesIO(image_file.read()), "test.jpg")
         }
-        response = client.post("/web/media/test.jpg", headers=auth_header,
+        response = api_client.post("/web/media/test.jpg", headers=auth_header,
                                content_type="multipart/form-data", data=data)
 
     assert response.status_code == http.HTTPStatus.CREATED
 
     # Test access of posted image
-    response = client.get("/media/instance/image/test.jpg")
+    response = api_client.get("/media/instance/image/test.jpg")
     assert response.status_code == http.HTTPStatus.OK
 
 
-def test_post_instance_media_file_with_attributes(client):
+def test_post_instance_media_file_with_attributes(api_client):
     # Disable CSRF for this test
-    client.application.config['WTF_CSRF_METHODS'] = []
+    api_client.application.config['WTF_CSRF_METHODS'] = []
 
-    auth_header = generate_webtoken(client.application, WebUser.Role.SCENARIO_ADMIN)
+    auth_header = generate_webtoken(api_client.application, WebUser.Role.SCENARIO_ADMIN)
 
     # Test post image
     with open(TEST_IMG_1, 'rb') as image_file:
@@ -52,7 +52,7 @@ def test_post_instance_media_file_with_attributes(client):
             "text": "Some test text.",
             "title": "The Title"
         }
-        response = client.post("/web/media/test.jpg", headers=auth_header,
+        response = api_client.post("/web/media/test.jpg", headers=auth_header,
                                content_type="multipart/form-data", data=data)
 
     assert response.status_code == http.HTTPStatus.CREATED
@@ -61,51 +61,51 @@ def test_post_instance_media_file_with_attributes(client):
     assert MediaData.from_json(response.data).text == "Some test text."
 
     # Test access of posted image
-    response = client.get("/media/instance/image/test.jpg")
+    response = api_client.get("/media/instance/image/test.jpg")
     assert response.status_code == http.HTTPStatus.OK
 
 
-def test_post_instance_media_text(client):
+def test_post_instance_media_text(api_client):
     # Disable CSRF for this test
-    client.application.config['WTF_CSRF_METHODS'] = []
+    api_client.application.config['WTF_CSRF_METHODS'] = []
 
-    auth_header = generate_webtoken(client.application, WebUser.Role.SCENARIO_ADMIN)
-    response = client.post("/web/media/txt", headers=auth_header, content_type="multipart/form-data",
+    auth_header = generate_webtoken(api_client.application, WebUser.Role.SCENARIO_ADMIN)
+    response = api_client.post("/web/media/txt", headers=auth_header, content_type="multipart/form-data",
                            data={"text": "Test"})
 
     assert response.status_code == http.HTTPStatus.CREATED
 
 
-def test_post_illegal_format(client):
+def test_post_illegal_format(api_client):
     # Disable CSRF for this test
-    client.application.config['WTF_CSRF_METHODS'] = []
+    api_client.application.config['WTF_CSRF_METHODS'] = []
 
-    auth_header = generate_webtoken(client.application, WebUser.Role.SCENARIO_ADMIN)
+    auth_header = generate_webtoken(api_client.application, WebUser.Role.SCENARIO_ADMIN)
 
     # Test post illegal data
     with open(__file__, 'rb') as illegal_file:
         data = {
             "file": (io.BytesIO(illegal_file.read()), "illegal.py")
         }
-        response = client.post("/web/media/test.png", headers=auth_header,
+        response = api_client.post("/web/media/test.png", headers=auth_header,
                                content_type="multipart/form-data", data=data)
 
     assert response.status_code == http.HTTPStatus.BAD_REQUEST
 
 
-def test_unauthorized_post(client):
+def test_unauthorized_post(api_client):
     # Disable CSRF for this test
-    client.application.config['WTF_CSRF_METHODS'] = []
+    api_client.application.config['WTF_CSRF_METHODS'] = []
 
-    auth_header = generate_webtoken(client.application, WebUser.Role.GAME_MASTER)
-    response = client.post("/web/media/txt", headers=auth_header, content_type="multipart/form-data",
+    auth_header = generate_webtoken(api_client.application, WebUser.Role.GAME_MASTER)
+    response = api_client.post("/web/media/txt", headers=auth_header, content_type="multipart/form-data",
                            data={"text": "Test"})
 
     assert response.status_code == http.HTTPStatus.FORBIDDEN
 
 
-def test_illegal_get(client):
-    response = client.get("media/static/../media.py")
+def test_illegal_get(api_client):
+    response = api_client.get("media/static/../media.py")
     assert response.status_code == http.HTTPStatus.NOT_FOUND
-    response = client.get("media/instance/../media.py")
+    response = api_client.get("media/instance/../media.py")
     assert response.status_code == http.HTTPStatus.NOT_FOUND

--- a/server/scenario/tests/test_scenario.py
+++ b/server/scenario/tests/test_scenario.py
@@ -8,8 +8,8 @@ Tests are deactivated, because they are designed for Debugging Cases in IDE.
 They are not appliable for pipeline.
 """
 
-def ttest_get_scenario(client):
-    response = client.get("/web/scenario?scenario_id=2")
+def ttest_get_scenario(web_client):
+    response = web_client.get("/web/scenario?scenario_id=2")
     response_data = response.get_json()
     assert response.status_code
     assert response_data["id"] == 2
@@ -18,9 +18,9 @@ def ttest_get_scenario(client):
     assert "vehicles" in response_data.keys()
 
 
-def ttest_add_vehicle_to_scenario(client):
+def ttest_add_vehicle_to_scenario(web_client):
 
-    response = client.get("/web/csrf")
+    response = web_client.get("/web/csrf")
     csrf_token = response.json["csrf_token"]
     csrf_header = {
         "X-CSRFToken": csrf_token
@@ -42,16 +42,16 @@ def ttest_add_vehicle_to_scenario(client):
         "vehicles_del": [],
     }
 
-    response = client.patch("/web/scenario", data=json.dumps(form),
+    response = web_client.patch("/web/scenario", data=json.dumps(form),
                             headers=csrf_header,
                             content_type='application/json')
 
     assert response.status_code == 200
 
 
-def ttest_create_scenario(client):
+def ttest_create_scenario(web_client):
 
-    response = client.get("/web/csrf")
+    response = web_client.get("/web/csrf")
     csrf_token = response.json["csrf_token"]
     csrf_header = {
         "X-CSRFToken": csrf_token
@@ -76,7 +76,7 @@ def ttest_create_scenario(client):
             },
         ],
     }
-    response = client.patch("/web/scenario", data=json.dumps(form),
+    response = web_client.patch("/web/scenario", data=json.dumps(form),
                             headers=csrf_header,
                             content_type='application/json')
     assert response.status_code == 200


### PR DESCRIPTION
This PR introduces a new way of testing. Therefore the test config stores different clients and apps. Depending on your test requirements you are in control of your environment setup. Further this PR includes  version upgrades in the action yml as well as a parallel setup for run test and code style.